### PR TITLE
fix(packs): remove duplicate schema_version in external/pack.yaml

### DIFF
--- a/astrid/packs/external/pack.yaml
+++ b/astrid/packs/external/pack.yaml
@@ -1,5 +1,4 @@
 schema_version: 1
 id: external
-schema_version: 1
 name: Astrid External Tools
 version: 1.0.0


### PR DESCRIPTION
One-line cleanup of a rebase artifact (duplicate `schema_version: 1` key). Pack schema + discovery tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)