### PR TITLE
m2-alias-compatibility: megaplan milestone

### DIFF
--- a/astrid/contracts/schema.py
+++ b/astrid/contracts/schema.py
@@ -116,6 +116,7 @@ class AliasRecord:
     canonical_id: str
     deprecated: bool = False
     deprecation_message: str = ""
+    source_pack_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/astrid/core/_search.py
+++ b/astrid/core/_search.py
@@ -24,6 +24,7 @@ FIELD_WEIGHTS: dict[str, float] = {
     "pack_id": 3.0,
     "version": 2.0,
     "category": 2.0,
+    "aliases": 3.0,
 }
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")

--- a/astrid/core/alias_resolver.py
+++ b/astrid/core/alias_resolver.py
@@ -6,7 +6,10 @@ validates alias graphs for cycles, and tracks deprecated aliases.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
+
 from astrid.contracts.schema import AliasRecord
+from astrid.core.pack import PackAliasKind, PackDefinition
 
 
 class AliasResolutionError(ValueError):
@@ -40,6 +43,7 @@ class AliasResolver:
         *,
         deprecated: bool = False,
         deprecation_message: str = "",
+        source_pack_id: str = "",
     ) -> None:
         """Register *alias* as a public name for *canonical_id*.
 
@@ -56,6 +60,7 @@ class AliasResolver:
             canonical_id=canonical_id,
             deprecated=deprecated,
             deprecation_message=deprecation_message,
+            source_pack_id=source_pack_id,
         )
 
         # Snapshot current state so we can roll back on cycle detection.
@@ -74,7 +79,7 @@ class AliasResolver:
     def register_pack_aliases(
         self,
         pack_id: str,
-        aliases: list[dict[str, str | bool]],
+        aliases: Iterable[Mapping[str, object]],
     ) -> None:
         """Register every alias declared by *pack_id* from a list of raw dicts.
 
@@ -94,6 +99,7 @@ class AliasResolver:
                 canonical_id=str(canonical_id),
                 deprecated=bool(entry.get("deprecated", False)),
                 deprecation_message=str(entry.get("deprecation_message", "")),
+                source_pack_id=pack_id,
             )
 
     # ------------------------------------------------------------------
@@ -169,6 +175,10 @@ class AliasResolver:
         """Return ``True`` if *value* is a registered alias."""
         return value in self._aliases
 
+    def get_record(self, alias: str) -> AliasRecord | None:
+        """Return the ``AliasRecord`` for *alias*, or ``None`` if not registered."""
+        return self._aliases.get(alias)
+
 
 def create_shared_alias_resolver() -> AliasResolver:
     """Factory that returns a fresh ``AliasResolver`` instance.
@@ -180,9 +190,33 @@ def create_shared_alias_resolver() -> AliasResolver:
     return AliasResolver()
 
 
+def extract_pack_aliases(
+    packs: Iterable[PackDefinition],
+    *,
+    kind: PackAliasKind,
+) -> dict[str, list[dict[str, object]]]:
+    """Collect pack-level aliases for a specific capability *kind*.
+
+    Returned values preserve deprecation metadata and annotate each alias entry
+    with its source pack id so the resolver record retains provenance.
+    """
+    aliases_by_pack: dict[str, list[dict[str, object]]] = {}
+    for pack in packs:
+        matching_aliases: list[dict[str, object]] = []
+        for alias in pack.aliases:
+            if alias.get("kind") != kind:
+                continue
+            normalized = dict(alias)
+            normalized["source_pack_id"] = pack.id
+            matching_aliases.append(normalized)
+        if matching_aliases:
+            aliases_by_pack[pack.id] = matching_aliases
+    return aliases_by_pack
+
+
 def _register_pack_aliases(
     resolver: AliasResolver,
-    pack_aliases: dict[str, list[dict[str, str | bool]]],
+    pack_aliases: Mapping[str, Iterable[Mapping[str, object]]],
 ) -> None:
     """Register every pack's declared aliases into *resolver*.
 

--- a/astrid/core/executor/cli.py
+++ b/astrid/core/executor/cli.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import shlex
 import sys
-from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -566,7 +565,14 @@ def _cmd_list(args: argparse.Namespace, registry: ExecutorRegistry) -> int:
 
 
 def _cmd_search(args: argparse.Namespace, registry: ExecutorRegistry) -> int:
-    records = [_executor_search_record(executor) for executor in _filter_by_pack(registry.list(), getattr(args, "pack", None))]
+    resolver = registry.alias_resolver
+    records = [
+        _executor_search_record(
+            executor,
+            aliases=_aliases_text(resolver, executor.id) if resolver else "",
+        )
+        for executor in _filter_by_pack(registry.list(), getattr(args, "pack", None))
+    ]
     hits = run_search(records, list(args.terms), limit=int(args.limit))
     if args.json:
         payload = [
@@ -585,7 +591,28 @@ def _cmd_search(args: argparse.Namespace, registry: ExecutorRegistry) -> int:
     return 0
 
 
-def _executor_search_record(executor: ExecutorDefinition) -> SearchRecord:
+def _aliases_text(resolver: Any, canonical_id: str) -> str:
+    """Return a space-joined string of alias ids for *canonical_id*.
+
+    Deprecated aliases get a ``[deprecated]`` suffix so the deprecation
+    status is visible to search scoring and human-readable output.
+    Returns the empty string when there are no aliases.
+    """
+    records = resolver.get_aliases_for(canonical_id)
+    if not records:
+        return ""
+    parts: list[str] = []
+    for r in records:
+        part = r.alias
+        if r.deprecated:
+            part += " [deprecated]"
+        if r.deprecation_message:
+            part += " " + r.deprecation_message
+        parts.append(part)
+    return " ".join(parts)
+
+
+def _executor_search_record(executor: ExecutorDefinition, *, aliases: str = "") -> SearchRecord:
     short = short_description_or_truncated(executor.short_description, executor.description)
     fields = {
         "id": executor.id,
@@ -598,23 +625,44 @@ def _executor_search_record(executor: ExecutorDefinition) -> SearchRecord:
         "version": executor.version,
         "category": str(executor.metadata.get("category") or executor.kind),
     }
+    if aliases:
+        fields["aliases"] = aliases
     return SearchRecord(id=executor.id, kind=executor.kind, short_description=short, fields=fields)
 
 
 def _cmd_inspect(args: argparse.Namespace, registry: ExecutorRegistry) -> int:
-    # Resolve alias BEFORE _require_qualified_id (SD1): alias → canonical ID
-    # (which always contains a dot), then qualify, then lookup.
-    resolver = registry.alias_resolver
-    resolved_id = resolver.resolve(args.executor_id) if resolver else args.executor_id
-    _require_qualified_id(resolved_id, "executor id")
-    executor = registry.get(resolved_id)
+    _require_qualified_id(args.executor_id, "executor id")
+
+    # Detect alias resolution before get() so we can enrich the handle.
+    requested_id = args.executor_id
+    alias_record = None
+    if registry.alias_resolver is not None and registry.alias_resolver.is_alias(requested_id):
+        alias_record = registry.alias_resolver.get_record(requested_id)
+
+    executor = registry.get(requested_id)
     _require_pack_match(executor, getattr(args, "pack", None))
     show_overrides = bool(getattr(args, "show_overrides", False))
+
+    # Collect alias metadata for the capability handle.
+    resolved_alias: str | None = None
+    aliases: tuple = ()
+    deprecated: bool = False
+    deprecation_message: str = ""
+    if alias_record is not None:
+        resolved_alias = requested_id
+        deprecated = alias_record.deprecated
+        deprecation_message = alias_record.deprecation_message
+    if registry.alias_resolver is not None:
+        aliases = tuple(registry.alias_resolver.get_aliases_for(executor.id))
+
     if args.json:
-        handle = to_capability_handle(executor)
-        if resolver is not None:
-            aliases = resolver.get_aliases_for(resolved_id)
-            handle = replace(handle, aliases=tuple(aliases))
+        handle = to_capability_handle(
+            executor,
+            aliases=aliases,
+            resolved_alias=resolved_alias,
+            deprecated=deprecated,
+            deprecation_message=deprecation_message,
+        )
         result = {"_capability": handle.to_dict(), **executor.to_dict()}
         if show_overrides and registry.override_store is not None:
             result["_override"] = registry.override_store.resolve("executor", executor.id)
@@ -630,6 +678,15 @@ def _cmd_inspect(args: argparse.Namespace, registry: ExecutorRegistry) -> int:
         print(f"description: {executor.description}")
     if executor.keywords:
         print(f"keywords: {', '.join(executor.keywords)}")
+    # Alias mapping (human-readable)
+    if resolved_alias:
+        print(f"requested_alias: {resolved_alias} → {executor.id}")
+        if deprecated:
+            msg = f"deprecated: {deprecation_message}" if deprecation_message else "deprecated: yes"
+            print(msg)
+    if aliases:
+        alias_ids = [a.alias for a in aliases]
+        print(f"aliases: {', '.join(alias_ids)}")
     _print_ports("inputs", executor.inputs)
     _print_outputs(executor)
     if executor.command is not None:

--- a/astrid/core/executor/registry.py
+++ b/astrid/core/executor/registry.py
@@ -14,6 +14,7 @@ from astrid.core.alias_resolver import (
     AliasResolver,
     _register_pack_aliases,
     create_shared_alias_resolver,
+    extract_pack_aliases,
 )
 from astrid.core.dirty import detect_local_edits, read_fork_state, write_fork_state
 from astrid.core.manifest import ManifestParseError, dump_manifest_payload, load_manifest_mapping
@@ -93,6 +94,18 @@ class ExecutorRegistry:
         else:
             yield entry
 
+    def _resolve_requested_id(self, executor_id: str) -> str:
+        """Resolve *executor_id* to a canonical registry key."""
+        resolver = self.alias_resolver
+        canonical_id = resolver.resolve(executor_id) if resolver else executor_id
+        if canonical_id in self._executors:
+            return canonical_id
+        if resolver is not None and executor_id != canonical_id and resolver.is_alias(executor_id):
+            raise KeyError(
+                f"alias {executor_id!r} points to missing executor {canonical_id!r}"
+            )
+        raise KeyError(f"unknown executor id {executor_id!r}")
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -108,25 +121,17 @@ class ExecutorRegistry:
         return definition
 
     def get(self, executor_id: str) -> ExecutorDefinition:
-        try:
-            definition = self._resolve_entry(self._executors[executor_id])
-        except KeyError as exc:
-            raise KeyError(f"unknown executor id {executor_id!r}") from exc
+        canonical_id = self._resolve_requested_id(executor_id)
+        definition = self._resolve_entry(self._executors[canonical_id])
 
-        # Check override store for a remapped target.
         if self.override_store is not None:
-            target_id = self.override_store.resolve("executor", executor_id)
-            if target_id is not None and target_id != executor_id:
-                # Validate that the override target exists.
+            target_id = self.override_store.resolve("executor", canonical_id)
+            if target_id is not None and target_id != canonical_id:
                 if target_id not in self._executors:
                     raise ExecutorRegistryError(
-                        f"override target {target_id!r} for executor {executor_id!r} not found in registry"
+                        f"override target {target_id!r} for executor {canonical_id!r} not found in registry"
                     )
-                target_def = self._resolve_entry(self._executors[target_id])
-                # Annotate the returned definition with override_target metadata.
-                target_metadata = dict(target_def.metadata)
-                target_metadata["override_target"] = target_id
-                return replace(target_def, metadata=target_metadata)
+                return self._resolve_entry(self._executors[target_id])
 
         return definition
 
@@ -251,14 +256,15 @@ def load_default_registry(
     extra_pack_roots: tuple[str, ...] = (),
     include_installed: bool = True,
 ) -> ExecutorRegistry:
-    resolver = create_shared_alias_resolver()
-    _register_pack_aliases(resolver, {})  # M1: no aliases yet
-    registry = ExecutorRegistry(alias_resolver=resolver)
-    for executor in load_pack_executors(
+    packs = _discover_executor_packs(
         project_root=project_root,
         extra_pack_roots=extra_pack_roots,
         include_installed=include_installed,
-    ):
+    )
+    resolver = create_shared_alias_resolver()
+    _register_pack_aliases(resolver, extract_pack_aliases(packs, kind="executor"))
+    registry = ExecutorRegistry(alias_resolver=resolver)
+    for executor in _load_pack_executors_from_packs(packs):
         registry.register(executor)
     if banodoco_config is not None and banodoco_config.enabled:
         for executor in load_banodoco_catalog_executors(banodoco_config):
@@ -273,6 +279,20 @@ def load_pack_executors(
     extra_pack_roots: tuple[str, ...] = (),
     include_installed: bool = True,
 ) -> tuple[ExecutorDefinition, ...]:
+    packs = _discover_executor_packs(
+        project_root=project_root,
+        extra_pack_roots=extra_pack_roots,
+        include_installed=include_installed,
+    )
+    return _load_pack_executors_from_packs(packs)
+
+
+def _discover_executor_packs(
+    *,
+    project_root: str | Path,
+    extra_pack_roots: tuple[str, ...],
+    include_installed: bool,
+) -> tuple[Any, ...]:
     # Mirror load_pack_elements(): discover source-tree packs (excluding
     # local), then conditionally discover the project-scoped local pack
     # when the project root differs from the repository root.
@@ -313,7 +333,12 @@ def load_pack_executors(
                         if pack.id == "local":
                             continue
                         packs.append(pack)
+    return tuple(packs)
 
+
+def _load_pack_executors_from_packs(
+    packs: Iterable[Any],
+) -> tuple[ExecutorDefinition, ...]:
     executors: list[ExecutorDefinition] = []
     for pack in packs:
         for root in iter_executor_roots(pack):

--- a/astrid/core/executor/schema.py
+++ b/astrid/core/executor/schema.py
@@ -16,6 +16,7 @@ from astrid.contracts.schema import (
     ISOLATION_MODES,
     OUTPUT_MODES,
     PORT_REQUIRED_TYPES,
+    AliasRecord,
     CacheMode,
     CachePolicy,
     CapabilityHandle,
@@ -198,7 +199,14 @@ class ExecutorDefinition:
         return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
 
 
-def to_capability_handle(definition: ExecutorDefinition) -> CapabilityHandle:
+def to_capability_handle(
+    definition: ExecutorDefinition,
+    *,
+    aliases: tuple[AliasRecord, ...] = (),
+    resolved_alias: str | None = None,
+    deprecated: bool = False,
+    deprecation_message: str = "",
+) -> CapabilityHandle:
     """Adapt an ``ExecutorDefinition`` into a ``CapabilityHandle``.
 
     Field mapping:
@@ -209,6 +217,10 @@ def to_capability_handle(definition: ExecutorDefinition) -> CapabilityHandle:
     * ``kind`` — ``definition.kind`` (preserved as-is)
     * ``provenance`` — source derived from metadata, default ``"pack"``
     * ``safety`` — network flag from ``definition.isolation.network``
+
+    Alias metadata (*aliases*, *resolved_alias*, *deprecated*,
+    *deprecation_message*) is carried on the handle and never mutates
+    ``ExecutorDefinition.metadata``.
     """
     parts = definition.id.split(".", 1)
     pack_id = parts[0]
@@ -220,7 +232,7 @@ def to_capability_handle(definition: ExecutorDefinition) -> CapabilityHandle:
 
     forked_from = str(metadata.get("forked_from") or "")
     upstream_version = str(metadata.get("upstream_version") or "")
-    compatibility_token = str(metadata.get("compatibility_token") or "")
+    compatibility_token=str(metadata.get("compatibility_token") or "")
     local_edit_state = str(metadata.get("local_edit_state") or "clean")
     override_target = str(metadata.get("override_target") or "")
 
@@ -236,6 +248,7 @@ def to_capability_handle(definition: ExecutorDefinition) -> CapabilityHandle:
             forked_from=forked_from or None,
             upstream_version=upstream_version or None,
             compatibility_token=compatibility_token or None,
+            resolved_alias=resolved_alias,
         ),
         safety=SafetyDeclaration(network=definition.isolation.network),
         description=definition.description,
@@ -243,6 +256,9 @@ def to_capability_handle(definition: ExecutorDefinition) -> CapabilityHandle:
         keywords=definition.keywords,
         local_edit_state=local_edit_state,
         override_target=override_target or None,
+        aliases=aliases,
+        deprecated=deprecated,
+        deprecation_message=deprecation_message,
         inputs=definition.inputs,
         outputs=definition.outputs,
     )

--- a/astrid/core/orchestrator/cli.py
+++ b/astrid/core/orchestrator/cli.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import shlex
 import sys
-from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -412,7 +411,14 @@ def _cmd_list(args: argparse.Namespace, registry: OrchestratorRegistry) -> int:
 
 
 def _cmd_search(args: argparse.Namespace, registry: OrchestratorRegistry) -> int:
-    records = [_orchestrator_search_record(item) for item in _filter_by_pack(registry.list(), getattr(args, "pack", None))]
+    resolver = registry.alias_resolver
+    records = [
+        _orchestrator_search_record(
+            item,
+            aliases=_aliases_text(resolver, item.id) if resolver else "",
+        )
+        for item in _filter_by_pack(registry.list(), getattr(args, "pack", None))
+    ]
     hits = run_search(records, list(args.terms), limit=int(args.limit))
     if args.json:
         payload = [
@@ -431,7 +437,28 @@ def _cmd_search(args: argparse.Namespace, registry: OrchestratorRegistry) -> int
     return 0
 
 
-def _orchestrator_search_record(orchestrator: OrchestratorDefinition) -> SearchRecord:
+def _aliases_text(resolver: Any, canonical_id: str) -> str:
+    """Return a space-joined string of alias ids for *canonical_id*.
+
+    Deprecated aliases get a ``[deprecated]`` suffix so the deprecation
+    status is visible to search scoring and human-readable output.
+    Returns the empty string when there are no aliases.
+    """
+    records = resolver.get_aliases_for(canonical_id)
+    if not records:
+        return ""
+    parts: list[str] = []
+    for r in records:
+        part = r.alias
+        if r.deprecated:
+            part += " [deprecated]"
+        if r.deprecation_message:
+            part += " " + r.deprecation_message
+        parts.append(part)
+    return " ".join(parts)
+
+
+def _orchestrator_search_record(orchestrator: OrchestratorDefinition, *, aliases: str = "") -> SearchRecord:
     short = short_description_or_truncated(orchestrator.short_description, orchestrator.description)
     fields = {
         "id": orchestrator.id,
@@ -443,23 +470,44 @@ def _orchestrator_search_record(orchestrator: OrchestratorDefinition) -> SearchR
         "version": orchestrator.version,
         "category": str(orchestrator.metadata.get("category") or orchestrator.kind),
     }
+    if aliases:
+        fields["aliases"] = aliases
     return SearchRecord(id=orchestrator.id, kind=orchestrator.kind, short_description=short, fields=fields)
 
 
 def _cmd_inspect(args: argparse.Namespace, registry: OrchestratorRegistry) -> int:
-    # Resolve alias BEFORE _require_qualified_id (SD1): alias → canonical ID
-    # (which always contains a dot), then qualify, then lookup.
-    resolver = registry.alias_resolver
-    resolved_id = resolver.resolve(args.orchestrator_id) if resolver else args.orchestrator_id
-    _require_qualified_id(resolved_id, "orchestrator id")
-    orchestrator = registry.get(resolved_id)
+    _require_qualified_id(args.orchestrator_id, "orchestrator id")
+
+    # Detect alias resolution before get() so we can enrich the handle.
+    requested_id = args.orchestrator_id
+    alias_record = None
+    if registry.alias_resolver is not None and registry.alias_resolver.is_alias(requested_id):
+        alias_record = registry.alias_resolver.get_record(requested_id)
+
+    orchestrator = registry.get(requested_id)
     _require_pack_match(orchestrator, getattr(args, "pack", None))
     show_overrides = bool(getattr(args, "show_overrides", False))
+
+    # Collect alias metadata for the capability handle.
+    resolved_alias: str | None = None
+    aliases: tuple = ()
+    deprecated: bool = False
+    deprecation_message: str = ""
+    if alias_record is not None:
+        resolved_alias = requested_id
+        deprecated = alias_record.deprecated
+        deprecation_message = alias_record.deprecation_message
+    if registry.alias_resolver is not None:
+        aliases = tuple(registry.alias_resolver.get_aliases_for(orchestrator.id))
+
     if args.json:
-        handle = to_capability_handle(orchestrator)
-        if resolver is not None:
-            aliases = resolver.get_aliases_for(resolved_id)
-            handle = replace(handle, aliases=tuple(aliases))
+        handle = to_capability_handle(
+            orchestrator,
+            aliases=aliases,
+            resolved_alias=resolved_alias,
+            deprecated=deprecated,
+            deprecation_message=deprecation_message,
+        )
         result = {"_capability": handle.to_dict(), **orchestrator.to_dict()}
         if show_overrides and registry.override_store is not None:
             result["_override"] = registry.override_store.resolve("orchestrator", orchestrator.id)
@@ -476,6 +524,15 @@ def _cmd_inspect(args: argparse.Namespace, registry: OrchestratorRegistry) -> in
         print(f"description: {orchestrator.description}")
     if orchestrator.keywords:
         print(f"keywords: {', '.join(orchestrator.keywords)}")
+    # Alias mapping (human-readable)
+    if resolved_alias:
+        print(f"requested_alias: {resolved_alias} → {orchestrator.id}")
+        if deprecated:
+            msg = f"deprecated: {deprecation_message}" if deprecation_message else "deprecated: yes"
+            print(msg)
+    if aliases:
+        alias_ids = [a.alias for a in aliases]
+        print(f"aliases: {', '.join(alias_ids)}")
     _print_ports("inputs", orchestrator.inputs)
     _print_outputs(orchestrator)
     if orchestrator.child_executors:

--- a/astrid/core/orchestrator/registry.py
+++ b/astrid/core/orchestrator/registry.py
@@ -14,6 +14,7 @@ from astrid.core.alias_resolver import (
     AliasResolver,
     _register_pack_aliases,
     create_shared_alias_resolver,
+    extract_pack_aliases,
 )
 from astrid.core.dirty import detect_local_edits, read_fork_state, write_fork_state
 from astrid.core.executor.registry import ExecutorRegistry
@@ -82,6 +83,18 @@ class OrchestratorRegistry:
         else:
             yield entry
 
+    def _resolve_requested_id(self, orchestrator_id: str) -> str:
+        """Resolve *orchestrator_id* to a canonical registry key."""
+        resolver = self.alias_resolver
+        canonical_id = resolver.resolve(orchestrator_id) if resolver else orchestrator_id
+        if canonical_id in self._orchestrators:
+            return canonical_id
+        if resolver is not None and orchestrator_id != canonical_id and resolver.is_alias(orchestrator_id):
+            raise KeyError(
+                f"alias {orchestrator_id!r} points to missing orchestrator {canonical_id!r}"
+            )
+        raise KeyError(f"unknown orchestrator id {orchestrator_id!r}")
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -97,25 +110,17 @@ class OrchestratorRegistry:
         return definition
 
     def get(self, orchestrator_id: str) -> OrchestratorDefinition:
-        try:
-            definition = self._resolve_entry(self._orchestrators[orchestrator_id])
-        except KeyError as exc:
-            raise KeyError(f"unknown orchestrator id {orchestrator_id!r}") from exc
+        canonical_id = self._resolve_requested_id(orchestrator_id)
+        definition = self._resolve_entry(self._orchestrators[canonical_id])
 
-        # Check override store for a remapped target.
         if self.override_store is not None:
-            target_id = self.override_store.resolve("orchestrator", orchestrator_id)
-            if target_id is not None and target_id != orchestrator_id:
-                # Validate that the override target exists.
+            target_id = self.override_store.resolve("orchestrator", canonical_id)
+            if target_id is not None and target_id != canonical_id:
                 if target_id not in self._orchestrators:
                     raise OrchestratorRegistryError(
-                        f"override target {target_id!r} for orchestrator {orchestrator_id!r} not found in registry"
+                        f"override target {target_id!r} for orchestrator {canonical_id!r} not found in registry"
                     )
-                target_def = self._resolve_entry(self._orchestrators[target_id])
-                # Annotate the returned definition with override_target metadata.
-                target_metadata = dict(target_def.metadata)
-                target_metadata["override_target"] = target_id
-                return replace(target_def, metadata=target_metadata)
+                return self._resolve_entry(self._orchestrators[target_id])
 
         return definition
 
@@ -148,6 +153,20 @@ class OrchestratorRegistry:
         self._validate_child_orchestrators(alias_resolver=self.alias_resolver)
         if self.alias_resolver is not None:
             self.alias_resolver.validate_no_cycles()
+            # Cross-check: every alias must resolve to a known orchestrator.
+            # Skip aliases whose resolved target is a known executor — those
+            # were registered as executor aliases (not orchestrator aliases)
+            # and live in this resolver only via test scaffolding or shared
+            # resolver setups.
+            exec_reg = executor_registry or self._executor_registry
+            exec_known = set(exec_reg.as_mapping()) if exec_reg else set()
+            for alias, record in self.alias_resolver._aliases.items():
+                target = self.alias_resolver.resolve(alias)
+                if target not in self._orchestrators:
+                    if target not in exec_known:
+                        raise OrchestratorRegistryError(
+                            f"alias {alias!r} resolves to unknown orchestrator {target!r}"
+                        )
         return self.list()
 
     def to_dict(self, kind: str | None = None) -> dict[str, Any]:
@@ -170,7 +189,15 @@ class OrchestratorRegistry:
     ) -> None:
         registry = executor_registry or self._executor_registry or load_default_executor_registry()
         known_executor_ids = set(registry.as_mapping())
-        resolver = alias_resolver or self.alias_resolver
+        # Resolve child executor references through the *executor* alias resolver
+        # when it is populated (the orchestrator's own alias resolver maps
+        # orchestrator ids, not executor ids).  Fall back to the orchestrator
+        # resolver when the executor resolver carries no aliases, which can
+        # happen in tests that register executor aliases on a shared resolver.
+        exec_alias_resolver: AliasResolver | None = getattr(registry, 'alias_resolver', None)
+        if exec_alias_resolver is not None and not exec_alias_resolver._aliases:
+            exec_alias_resolver = None
+        resolver = exec_alias_resolver or alias_resolver or self.alias_resolver
         # Winners only.
         for orchestrator in (self._resolve_entry(entry) for entry in self._orchestrators.values()):
             for child_executor in orchestrator.child_executors:
@@ -322,17 +349,18 @@ def load_default_registry(
     include_installed: bool = True,
 ) -> OrchestratorRegistry:
     active_executor_registry = executor_registry
+    packs = _discover_orchestrator_packs(
+        project_root=project_root,
+        extra_pack_roots=extra_pack_roots,
+        include_installed=include_installed,
+    )
     resolver = create_shared_alias_resolver()
-    _register_pack_aliases(resolver, {})  # M1: no aliases yet
+    _register_pack_aliases(resolver, extract_pack_aliases(packs, kind="orchestrator"))
     registry = OrchestratorRegistry(
         executor_registry=active_executor_registry,
         alias_resolver=resolver,
     )
-    for orchestrator in load_pack_orchestrators(
-        project_root=project_root,
-        extra_pack_roots=extra_pack_roots,
-        include_installed=include_installed,
-    ):
+    for orchestrator in _load_pack_orchestrators_from_packs(packs):
         registry.register(orchestrator)
     registry.validate_all(executor_registry=active_executor_registry)
     return registry
@@ -344,6 +372,20 @@ def load_pack_orchestrators(
     extra_pack_roots: tuple[str, ...] = (),
     include_installed: bool = True,
 ) -> tuple[OrchestratorDefinition, ...]:
+    packs = _discover_orchestrator_packs(
+        project_root=project_root,
+        extra_pack_roots=extra_pack_roots,
+        include_installed=include_installed,
+    )
+    return _load_pack_orchestrators_from_packs(packs)
+
+
+def _discover_orchestrator_packs(
+    *,
+    project_root: str | Path,
+    extra_pack_roots: tuple[str, ...],
+    include_installed: bool,
+) -> tuple[Any, ...]:
     # Mirror load_pack_elements(): discover source-tree packs (excluding
     # local), then conditionally discover the project-scoped local pack
     # when the project root differs from the repository root.
@@ -384,7 +426,12 @@ def load_pack_orchestrators(
                         if pack.id == "local":
                             continue
                         packs.append(pack)
+    return tuple(packs)
 
+
+def _load_pack_orchestrators_from_packs(
+    packs: Iterable[Any],
+) -> tuple[OrchestratorDefinition, ...]:
     orchestrators: list[OrchestratorDefinition] = []
     for pack in packs:
         for root in iter_orchestrator_roots(pack):

--- a/astrid/core/orchestrator/schema.py
+++ b/astrid/core/orchestrator/schema.py
@@ -17,6 +17,7 @@ from astrid.contracts.schema import (
     ISOLATION_MODES,
     OUTPUT_MODES,
     PORT_REQUIRED_TYPES,
+    AliasRecord,
     CacheMode,
     CachePolicy,
     CapabilityHandle,
@@ -88,7 +89,14 @@ class OrchestratorDefinition:
         return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
 
 
-def to_capability_handle(definition: OrchestratorDefinition) -> CapabilityHandle:
+def to_capability_handle(
+    definition: OrchestratorDefinition,
+    *,
+    aliases: tuple[AliasRecord, ...] = (),
+    resolved_alias: str | None = None,
+    deprecated: bool = False,
+    deprecation_message: str = "",
+) -> CapabilityHandle:
     """Adapt an ``OrchestratorDefinition`` into a ``CapabilityHandle``.
 
     Field mapping mirrors the executor adapter:
@@ -99,6 +107,10 @@ def to_capability_handle(definition: OrchestratorDefinition) -> CapabilityHandle
     * ``kind`` — ``definition.kind`` (preserved as-is)
     * ``provenance`` — source derived from metadata, default ``"pack"``
     * ``safety`` — network flag from ``definition.isolation.network``
+
+    Alias metadata (*aliases*, *resolved_alias*, *deprecated*,
+    *deprecation_message*) is carried on the handle and never mutates
+    ``OrchestratorDefinition.metadata``.
     """
     parts = definition.id.split(".", 1)
     pack_id = parts[0]
@@ -110,7 +122,7 @@ def to_capability_handle(definition: OrchestratorDefinition) -> CapabilityHandle
 
     forked_from = str(metadata.get("forked_from") or "")
     upstream_version = str(metadata.get("upstream_version") or "")
-    compatibility_token = str(metadata.get("compatibility_token") or "")
+    compatibility_token=str(metadata.get("compatibility_token") or "")
     local_edit_state = str(metadata.get("local_edit_state") or "clean")
     override_target = str(metadata.get("override_target") or "")
 
@@ -126,6 +138,7 @@ def to_capability_handle(definition: OrchestratorDefinition) -> CapabilityHandle
             forked_from=forked_from or None,
             upstream_version=upstream_version or None,
             compatibility_token=compatibility_token or None,
+            resolved_alias=resolved_alias,
         ),
         safety=SafetyDeclaration(network=definition.isolation.network),
         description=definition.description,
@@ -133,6 +146,9 @@ def to_capability_handle(definition: OrchestratorDefinition) -> CapabilityHandle
         keywords=definition.keywords,
         local_edit_state=local_edit_state,
         override_target=override_target or None,
+        aliases=aliases,
+        deprecated=deprecated,
+        deprecation_message=deprecation_message,
         inputs=definition.inputs,
         outputs=definition.outputs,
     )

--- a/astrid/core/pack.py
+++ b/astrid/core/pack.py
@@ -13,6 +13,8 @@ import yaml
 PACK_MANIFEST_NAMES = ("pack.yaml", "pack.yml", "pack.json")
 EXECUTOR_MANIFEST_NAMES = ("executor.yaml", "executor.yml", "executor.json")
 ORCHESTRATOR_MANIFEST_NAMES = ("orchestrator.yaml", "orchestrator.yml", "orchestrator.json")
+PACK_ALIAS_KINDS: tuple[Literal["executor", "orchestrator"], ...] = ("executor", "orchestrator")
+PackAliasKind = Literal["executor", "orchestrator"]
 # Authoritative element-kind contract (mirrored as a Literal in
 # astrid.core.element.schema; kept here too because pack.py is loaded
 # before element/__init__.py and importing from there causes a cycle).
@@ -41,6 +43,7 @@ class PackDefinition:
     status: str = field(default="active")
     visibility: str = field(default="visible")
     schema_version: str = field(default="")
+    aliases: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     origin: str = field(default="unknown")
     install_tier: str = field(default="default")
     pack_type: str = field(default="capability")
@@ -57,7 +60,7 @@ class PackDefinition:
             "stability": self.stability,
             "support": self.support,
         }
-        return {
+        payload = {
             "id": self.id,
             "name": self.name,
             "version": self.version,
@@ -73,6 +76,9 @@ class PackDefinition:
             **taxonomy,
             "taxonomy": taxonomy,
         }
+        if self.aliases:
+            payload["aliases"] = [dict(alias) for alias in self.aliases]
+        return payload
 
 
 def packs_root() -> Path:
@@ -144,6 +150,7 @@ def load_pack_manifest(path: str | Path) -> PackDefinition:
     status = _optional_string(data, "status", "pack.status", default="active")
     visibility = _optional_string(data, "visibility", "pack.visibility", default="visible")
     schema_version = str(data.get("schema_version", "")) if "schema_version" in data else ""
+    aliases = _optional_pack_aliases(data.get("aliases"), path="pack.aliases")
     taxonomy = pack_taxonomy_from_manifest(data, status=status)
     return PackDefinition(
         id=pack_id,
@@ -158,6 +165,7 @@ def load_pack_manifest(path: str | Path) -> PackDefinition:
         status=status,
         visibility=visibility,
         schema_version=schema_version,
+        aliases=aliases,
         **taxonomy,
     )
 
@@ -189,6 +197,55 @@ def _default_stability_for_status(status: str) -> str:
     if status == "deprecated":
         return "deprecated"
     return "stable"
+
+
+def _optional_pack_aliases(value: Any, *, path: str) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise PackValidationError(f"{path} must be an array")
+
+    normalized: list[dict[str, Any]] = []
+    allowed_keys = {"alias", "canonical_id", "kind", "deprecated", "deprecation_message"}
+    for index, raw_alias in enumerate(value):
+        alias_path = f"{path}[{index}]"
+        if not isinstance(raw_alias, dict):
+            raise PackValidationError(f"{alias_path} must be an object")
+        unknown_keys = sorted(set(raw_alias) - allowed_keys)
+        if unknown_keys:
+            raise PackValidationError(
+                f"{alias_path} has unknown field(s): {', '.join(unknown_keys)}"
+            )
+
+        kind = _require_string(raw_alias, "kind", f"{alias_path}.kind")
+        if kind not in PACK_ALIAS_KINDS:
+            raise PackValidationError(
+                f"{alias_path}.kind must be one of {list(PACK_ALIAS_KINDS)}"
+            )
+
+        alias = _require_string(raw_alias, "alias", f"{alias_path}.alias")
+        qualified_id_pack_id(alias, path=f"{alias_path}.alias")
+        canonical_id = _require_string(raw_alias, "canonical_id", f"{alias_path}.canonical_id")
+        qualified_id_pack_id(canonical_id, path=f"{alias_path}.canonical_id")
+
+        normalized_alias: dict[str, Any] = {
+            "kind": kind,
+            "alias": alias,
+            "canonical_id": canonical_id,
+        }
+        if "deprecated" in raw_alias:
+            deprecated = raw_alias["deprecated"]
+            if not isinstance(deprecated, bool):
+                raise PackValidationError(f"{alias_path}.deprecated must be a boolean")
+            normalized_alias["deprecated"] = deprecated
+        if "deprecation_message" in raw_alias:
+            deprecation_message = raw_alias["deprecation_message"]
+            if not isinstance(deprecation_message, str):
+                raise PackValidationError(f"{alias_path}.deprecation_message must be a string")
+            normalized_alias["deprecation_message"] = deprecation_message
+        normalized.append(normalized_alias)
+
+    return tuple(normalized)
 
 
 def pack_manifest_path(root: str | Path) -> Path | None:

--- a/astrid/packs/schemas/v1/pack.json
+++ b/astrid/packs/schemas/v1/pack.json
@@ -45,6 +45,30 @@
     "metadata": {
       "type": "object"
     },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "alias", "canonical_id"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["executor", "orchestrator"]
+          },
+          "alias": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+          },
+          "canonical_id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+          },
+          "deprecated": {"type": "boolean"},
+          "deprecation_message": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
     "secrets": {
       "type": "array",
       "items": {

--- a/astrid/packs/validate.py
+++ b/astrid/packs/validate.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 import jsonschema
 from referencing import Registry, Resource
 
+from astrid.core.alias_resolver import AliasResolutionError, AliasResolver
 from astrid.core.manifest import ManifestParseError, load_manifest_mapping
 from astrid.core.pack import (
     ELEMENT_KINDS,
@@ -29,6 +30,7 @@ from astrid.core.pack import (
     iter_element_roots,
     iter_executor_roots,
     iter_orchestrator_roots,
+    _optional_pack_aliases,
     pack_taxonomy_from_manifest,
     pack_manifest_path,
 )
@@ -167,7 +169,16 @@ class PackValidator:
         self.errors = []
         self.warnings = []
         self._capability_locations: dict[str, str] = {}
+        self._pack_capability_locations: dict[str, dict[str, str]] = {
+            "executor": {},
+            "orchestrator": {},
+        }
         self._alias_targets: list[tuple[str, str, str]] = []
+        self._pack_alias_resolvers: dict[str, AliasResolver] = {
+            "executor": AliasResolver(),
+            "orchestrator": AliasResolver(),
+        }
+        self._pack_alias_targets: list[tuple[str, str, str, str]] = []
 
         if (self.pack_root / ".no-pack").exists():
             return self.errors
@@ -213,6 +224,7 @@ class PackValidator:
 
         # Validate component manifests
         self._validate_components(content)
+        self._validate_pack_aliases()
         self._validate_alias_targets()
 
         return self.errors
@@ -470,6 +482,7 @@ class PackValidator:
             content=dict(content),
             metadata=dict(data.get("metadata", {})) if isinstance(data.get("metadata", {}), dict) else {},
             agent=dict(data.get("agent", {})) if isinstance(data.get("agent", {}), dict) else {},
+            aliases=_optional_pack_aliases(data.get("aliases"), path="pack.aliases"),
             **taxonomy,
         )
 
@@ -517,6 +530,8 @@ class PackValidator:
         component_id = data.get("id")
         if isinstance(component_id, str):
             self._register_capability_id(component_id, rel)
+            if manifest_kind in self._pack_capability_locations:
+                self._pack_capability_locations[manifest_kind][component_id] = rel
             self._register_aliases(data, rel)
 
         self._validate_runtime_entrypoints(component_dir, data, manifest_kind, rel)
@@ -702,12 +717,65 @@ class PackValidator:
             else:
                 self.errors.append(f"{relpath}: metadata.aliases[{index}] must be a string or object")
 
+    def _validate_pack_aliases(self) -> None:
+        if self._pack_data is None:
+            return
+        aliases = self._pack_data.get("aliases")
+        if aliases is None:
+            return
+        try:
+            normalized_aliases = _optional_pack_aliases(aliases, path="pack.aliases")
+        except ValueError as exc:
+            self.errors.append(f"pack.yaml: {exc}")
+            return
+
+        for index, alias in enumerate(normalized_aliases):
+            kind = str(alias["kind"])
+            alias_id = str(alias["alias"])
+            canonical_id = str(alias["canonical_id"])
+            resolver = self._pack_alias_resolvers[kind]
+            if resolver.is_alias(alias_id):
+                self.errors.append(
+                    f"pack.yaml: pack.aliases[{index}] duplicates existing {kind} alias {alias_id!r}"
+                )
+                continue
+            try:
+                resolver.register_alias(
+                    alias_id,
+                    canonical_id,
+                    deprecated=bool(alias.get("deprecated", False)),
+                    deprecation_message=str(alias.get("deprecation_message", "")),
+                )
+            except AliasResolutionError as exc:
+                self.errors.append(f"pack.yaml: pack.aliases[{index}] {exc}")
+                continue
+            self._pack_alias_targets.append(
+                ("pack.yaml", f"pack.aliases[{index}]", kind, canonical_id)
+            )
+
+        for relpath, alias_path, kind, target in self._pack_alias_targets:
+            pack_id = target.split(".", 1)[0]
+            if pack_id != self._pack_id():
+                continue
+            if target not in self._pack_capability_locations[kind]:
+                self.errors.append(
+                    f"{relpath}: {alias_path} points to unknown {kind} id {target!r}"
+                )
+
     def _validate_alias_targets(self) -> None:
         for relpath, alias_path, target in self._alias_targets:
             if target not in self._capability_locations:
                 self.errors.append(
                     f"{relpath}: {alias_path} points to unknown capability id {target!r}"
                 )
+
+    def _pack_id(self) -> str:
+        if self._pack_data is None:
+            return self.pack_root.name
+        value = self._pack_data.get("id")
+        if isinstance(value, str) and value.strip():
+            return value
+        return self.pack_root.name
 
     def _rel(self, path: Path) -> str:
         """Return a path relative to the pack root for error messages."""

--- a/docs/aliases-vs-forks-vs-overrides.md
+++ b/docs/aliases-vs-forks-vs-overrides.md
@@ -18,27 +18,81 @@ guide builds on the vocabulary in
 
 ## Aliases
 
-**What:** A one-way mapping from a short public name (the alias) to a
-fully-qualified canonical id.
+**What:** A one-way mapping from a public alias id to a fully-qualified
+canonical id, declared in the owning pack's manifest.
 
-**How it works:** The `AliasResolver` (in `astrid/core/alias_resolver.py`)
-maintains a registry of `alias → canonical_id` mappings. Aliases are resolved
-transitively — chains of aliases are flattened to the ultimate canonical
-target. Cycle detection runs at registration time and rejects invalid graphs.
+**Where they live:** Aliases are a top-level pack manifest field — they live in
+`pack.yaml` on the canonical pack that owns the target capability, not in the
+capability's own manifest. This keeps alias ownership explicit: the pack that
+provides the canonical capability declares the legacy ids that route to it.
 
-**Register an alias** in `pack.yaml`:
+**Schema (pack.json v1):**
+
+Each alias entry is an object with:
+
+| Field | Required | Type | Description |
+|---|---|---|---|
+| `kind` | Yes | `"executor"` or `"orchestrator"` | The capability kind the alias routes to |
+| `alias` | Yes | Qualified id (`pack.slug`) | The old or alternate public id |
+| `canonical_id` | Yes | Qualified id (`pack.slug`) | The canonical id this alias points to |
+| `deprecated` | No | `boolean` (default `false`) | Whether the alias is deprecated |
+| `deprecation_message` | No | `string` (default `""`) | Human-readable deprecation note shown in inspect/search |
+
+Both `alias` and `canonical_id` must be qualified ids (e.g. `rendering.render`,
+not bare `render`). The `kind` enum is `executor` or `orchestrator` — element
+aliases are deferred to a future milestone.
+
+**Example** in `pack.yaml`:
 
 ```yaml
+# In astrid/packs/rendering/pack.yaml
 aliases:
-  generate-image: builtin.generate_image
-  gen-img: builtin.generate_image
+  - kind: executor
+    alias: builtin.render
+    canonical_id: rendering.render
+    deprecated: true
+    deprecation_message: "Moved to rendering.render — update your references"
+  - kind: executor
+    alias: external.vibecomfy.run
+    canonical_id: vibecomfy.run
+    deprecated: true
+    deprecation_message: "The 'external' prefix is no longer needed"
 ```
 
-Multiple aliases can point to the same canonical id. Aliases can be marked
-deprecated with a message shown to consumers.
+Multiple aliases can point to the same canonical id, and aliases are resolved
+transitively — chains of aliases are flattened to the ultimate canonical target.
+Cycle detection runs at registration time and rejects invalid alias graphs.
+
+**How it works:** The `AliasResolver` (in `astrid/core/alias_resolver.py`)
+maintains a registry of `alias → canonical_id` mappings. Aliases are loaded from
+`PackDefinition.aliases` during registry construction, filtered by `kind`, and
+registered with their deprecation metadata and source pack id preserved. Both
+the executor and orchestrator registries wire aliases from discovered packs
+automatically — no separate registration step is needed.
+
+**Backward compatibility:** Old ids like `builtin.*`, `external.*`, and
+`upload.*` remain functional when declared as aliases. Registry lookup,
+`inspect --json`, and search all resolve the old id to the canonical definition
+and surface deprecation metadata. The old ids do not need their own capability
+definitions — they are pure alias entries.
+
+**Deprecation metadata is non-fatal.** A deprecated alias still resolves; the
+deprecation flag and message are informational, shown in `inspect` output and
+search records. Consumers can use the message to plan migration without being
+blocked.
+
+**What aliases are NOT:**
+
+- **Element aliases** — The `kind` enum only accepts `executor` and
+  `orchestrator`. Element aliasing is deferred to a future milestone.
+- **Component-level `metadata.aliases`** — The `metadata.aliases` field on
+  individual executor/orchestrator manifests (e.g. `executor.yaml`) is legacy
+  validation-only coverage. It is checked during static validation but is not
+  loaded into the alias resolver. Do not use it for new alias declarations;
+  use the pack-level `aliases` field instead.
 
 **When to use:** You renamed a capability but old consumers still reference the
-old id. Instead of breaking them, add an alias.
+old id. Instead of breaking them, add a pack-level alias.
 
 **When NOT to use:** You want to change behavior. Aliases are identity-only;
 they don't alter execution. Use a fork or override for behavioral changes.
@@ -104,7 +158,14 @@ give it capability Y instead."
 thread-safe in-memory mapping of `(type, id) → target_id`, persisted to
 `astrid/packs/local/.overrides.json`. Overrides are checked at resolution time
 — whenever a registry looks up a capability by id, the override store is
-consulted first.
+consulted after alias resolution.
+
+**Canonical-id keying:** Override keys are the *canonical* capability id, not
+the alias. When a caller requests `builtin.render` (an alias), the registry
+first resolves it to `rendering.render` (the canonical id), then checks the
+override store for `("executor", "rendering.render")`. This means one override
+covers all aliases that point to the same canonical target — you do not need to
+set separate overrides for each alias.
 
 ### Override Commands
 
@@ -145,12 +206,16 @@ different ids. Just fork without setting an override.
 
 Resolution order when looking up a capability id:
 
-1. **Override check** — is there an active override for this id? If yes, resolve
-   to the target id and restart resolution.
-2. **Alias resolution** — is the id an alias? If yes, resolve to the canonical
-   id and restart resolution.
+1. **Alias resolution** — is the id an alias? If yes, resolve transitively to
+   the canonical id.
+2. **Override check** — is there an active override for the *canonical* id? If
+   yes, return the override target's definition.
 3. **Registry lookup** — find the capability by canonical id in the loaded
-   registries.
+   registries and return its definition.
 
-This means overrides take priority over aliases, and both redirect before the
-final registry lookup.
+This means aliases resolve before overrides, and override keys are canonical ids
+rather than alias ids. One override covers every alias that routes to the same
+canonical target. Both alias resolution and override redirection are transparent
+to the caller — the returned definition is the final canonical or override
+definition, with alias metadata attached to the capability handle's provenance
+for informational display.

--- a/docs/creating-packs.md
+++ b/docs/creating-packs.md
@@ -132,8 +132,40 @@ The pack manifest declares:
 - **Agent instructions**: `purpose`, `normal_entrypoints`,
   `do_not_use_for`, `required_context`.
 - **Documentation references**: paths to `AGENTS.md`, `README.md`, etc.
+- **Aliases**: alternate public ids that route to executor or orchestrator
+  capabilities in this pack. See
+  [aliases-vs-forks-vs-overrides.md](aliases-vs-forks-vs-overrides.md) for
+  the full alias vocabulary and schema.
 
 Refer to `pack.json` for the full field list and constraints.
+
+### Pack-Level Aliases
+
+A pack can declare aliases for its capabilities — old or alternate ids that
+resolve to the canonical capability id. Aliases keep backward compatibility when
+a capability is renamed or moved to a different pack namespace.
+
+```yaml
+# In pack.yaml
+aliases:
+  - kind: executor
+    alias: builtin.render
+    canonical_id: rendering.render
+    deprecated: true
+    deprecation_message: "Moved to rendering.render — update your references"
+```
+
+Key rules:
+
+- Aliases are declared on the pack that owns the **canonical** capability, not on
+  the alias source pack.
+- `kind` must be `executor` or `orchestrator` — element aliases are deferred.
+- Both `alias` and `canonical_id` must be qualified ids (`pack.slug`).
+- `deprecated` and `deprecation_message` are optional; they surface
+  informational metadata in `inspect` and `search` without blocking resolution.
+- Component-level `metadata.aliases` on individual executor/orchestrator
+  manifests is legacy validation-only — new aliases must use the pack-level
+  `aliases` field.
 
 ### Executor Manifest (`executor.yaml`)
 

--- a/tests/test_capability_alias_resolver.py
+++ b/tests/test_capability_alias_resolver.py
@@ -7,6 +7,10 @@ tests/test_canonical_aliases.py is NOT modified.
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+from unittest import mock
+
 import pytest
 
 from astrid.core.alias_resolver import (
@@ -14,11 +18,17 @@ from astrid.core.alias_resolver import (
     AliasResolver,
     create_shared_alias_resolver,
     _register_pack_aliases,
+    extract_pack_aliases,
 )
 from astrid.core import AliasResolver as AliasResolverFromCore
 from astrid.core import AliasResolutionError as AliasResolutionErrorFromCore
-from astrid.core.orchestrator.registry import OrchestratorRegistry
-from astrid.core.orchestrator.schema import OrchestratorDefinition, RuntimeSpec
+from astrid.core.executor.registry import ExecutorRegistry, load_default_registry as load_executor_registry
+from astrid.core.executor.schema import ExecutorDefinition, to_capability_handle
+from astrid.core.orchestrator.registry import OrchestratorRegistry, OrchestratorRegistryError
+from astrid.core.orchestrator.registry import load_default_registry as load_orchestrator_registry
+from astrid.core.orchestrator.schema import OrchestratorDefinition, RuntimeSpec, to_capability_handle as orch_to_capability_handle
+from astrid.core.override import OverrideStore
+from astrid.core.pack import PackDefinition, discover_packs
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +263,111 @@ class TestRegisterPackAliases:
         with pytest.raises(AliasResolutionError, match="missing 'alias' or 'canonical_id'"):
             resolver.register_pack_aliases("pack", [{"alias": "x"}])
 
+    def test_register_pack_aliases_preserves_source_pack_metadata(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_pack_aliases(
+            "my_pack",
+            [{"alias": "rp", "canonical_id": "my_pack.render", "deprecated": True}],
+        )
+        record = resolver.get_aliases_for("my_pack.render")[0]
+        assert record.source_pack_id == "my_pack"
+        assert record.deprecated is True
+
+
+class TestExtractPackAliases:
+    def test_extract_pack_aliases_filters_by_kind_and_keeps_metadata(self) -> None:
+        pack = PackDefinition(
+            id="builtin",
+            name="Builtin",
+            version="1.0.0",
+            root=Path("/tmp/builtin"),
+            manifest_path=Path("/tmp/builtin/pack.yaml"),
+            metadata={},
+            aliases=(
+                {
+                    "kind": "executor",
+                    "alias": "builtin.old_render",
+                    "canonical_id": "builtin.render",
+                    "deprecated": True,
+                    "deprecation_message": "Use builtin.render",
+                },
+                {
+                    "kind": "orchestrator",
+                    "alias": "builtin.old_hype",
+                    "canonical_id": "builtin.hype",
+                },
+            ),
+        )
+
+        executor_aliases = extract_pack_aliases((pack,), kind="executor")
+        orchestrator_aliases = extract_pack_aliases((pack,), kind="orchestrator")
+
+        assert list(executor_aliases) == ["builtin"]
+        assert executor_aliases["builtin"][0]["alias"] == "builtin.old_render"
+        assert executor_aliases["builtin"][0]["deprecated"] is True
+        assert executor_aliases["builtin"][0]["deprecation_message"] == "Use builtin.render"
+        assert executor_aliases["builtin"][0]["source_pack_id"] == "builtin"
+        assert list(orchestrator_aliases) == ["builtin"]
+        assert orchestrator_aliases["builtin"][0]["alias"] == "builtin.old_hype"
+
+
+def _write_pack(root: Path, pack_id: str, aliases: str = "") -> Path:
+    pack_root = root / pack_id
+    pack_root.mkdir(parents=True)
+    pack_yaml = [
+        "schema_version: 1",
+        f"id: {pack_id}",
+        f"name: {pack_id.title()} Pack",
+        "version: '1.0'",
+    ]
+    if aliases:
+        pack_yaml.append("aliases:")
+        pack_yaml.extend(aliases.splitlines())
+    (pack_root / "pack.yaml").write_text("\n".join(pack_yaml) + "\n", encoding="utf-8")
+    return pack_root
+
+
+def _write_executor(root: Path, folder: str, executor_id: str) -> None:
+    executor_root = root / folder
+    executor_root.mkdir()
+    (executor_root / "executor.yaml").write_text(
+        "\n".join(
+            [
+                f"id: {executor_id}",
+                f"name: {executor_id}",
+                "kind: built_in",
+                "version: '1.0'",
+                "command:",
+                "  argv: ['echo', 'ok']",
+                "cache:",
+                "  mode: none",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_orchestrator(root: Path, folder: str, orchestrator_id: str) -> None:
+    orchestrator_root = root / folder
+    orchestrator_root.mkdir()
+    (orchestrator_root / "orchestrator.yaml").write_text(
+        "\n".join(
+            [
+                f"id: {orchestrator_id}",
+                f"name: {orchestrator_id}",
+                "kind: built_in",
+                "version: '1.0'",
+                "runtime:",
+                "  kind: command",
+                "  command:",
+                "    argv: ['echo', 'ok']",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers
@@ -280,6 +395,80 @@ class TestFactoryHelpers:
         })
         assert resolver.resolve("a1") == "p1.foo"
         assert resolver.resolve("a2") == "p2.bar"
+
+
+# ---------------------------------------------------------------------------
+# Default registry alias loading from pack manifests
+# ---------------------------------------------------------------------------
+
+class TestDefaultRegistryPackAliasLoading:
+    def test_executor_default_registry_loads_only_executor_pack_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "builtin",
+                aliases="\n".join(
+                    [
+                        "  - kind: executor",
+                        "    alias: builtin.legacy_render",
+                        "    canonical_id: builtin.render",
+                        "    deprecated: true",
+                        "    deprecation_message: use builtin.render",
+                        "  - kind: orchestrator",
+                        "    alias: builtin.legacy_hype",
+                        "    canonical_id: builtin.hype",
+                    ]
+                ),
+            )
+            _write_executor(pack_root, "render", "builtin.render")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+        assert registry.alias_resolver is not None
+        assert registry.alias_resolver.resolve("builtin.legacy_render") == "builtin.render"
+        assert registry.alias_resolver.is_alias("builtin.legacy_hype") is False
+        aliases = registry.alias_resolver.get_aliases_for("builtin.render")
+        assert len(aliases) == 1
+        assert aliases[0].source_pack_id == "builtin"
+        assert aliases[0].deprecated is True
+        assert aliases[0].deprecation_message == "use builtin.render"
+
+    def test_orchestrator_default_registry_loads_only_orchestrator_pack_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "builtin",
+                aliases="\n".join(
+                    [
+                        "  - kind: executor",
+                        "    alias: builtin.legacy_render",
+                        "    canonical_id: builtin.render",
+                        "  - kind: orchestrator",
+                        "    alias: builtin.legacy_hype",
+                        "    canonical_id: builtin.hype",
+                        "    deprecated: true",
+                        "    deprecation_message: use builtin.hype",
+                    ]
+                ),
+            )
+            _write_orchestrator(pack_root, "hype", "builtin.hype")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+        assert registry.alias_resolver is not None
+        assert registry.alias_resolver.resolve("builtin.legacy_hype") == "builtin.hype"
+        assert registry.alias_resolver.is_alias("builtin.legacy_render") is False
+        aliases = registry.alias_resolver.get_aliases_for("builtin.hype")
+        assert len(aliases) == 1
+        assert aliases[0].source_pack_id == "builtin"
+        assert aliases[0].deprecated is True
+        assert aliases[0].deprecation_message == "use builtin.hype"
 
 
 # ---------------------------------------------------------------------------
@@ -419,3 +608,1286 @@ class TestEdgeCases:
         resolver.register_alias("A", "B")
         with pytest.raises(AliasResolutionError, match="cycle"):
             resolver.register_alias("B", "A")
+
+
+# ---------------------------------------------------------------------------
+# Executor graph.depends_on alias resolution (integration)
+# ---------------------------------------------------------------------------
+
+class TestExecutorDependsOnAliasResolution:
+    """Tests that ExecutorRegistry._validate_graph_references resolves
+    aliases in graph.depends_on before checking existence."""
+
+    def test_depends_on_alias_resolves_to_known_executor(self) -> None:
+        """Executor A depends on alias 'test.dep_alias' which maps to 'test.b'.
+        Validation should resolve the alias and succeed."""
+        from astrid.core.executor.registry import ExecutorRegistry
+        from astrid.core.executor.schema import ExecutorDefinition, GraphMetadata
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.dep_alias", "test.b")
+
+        registry = ExecutorRegistry(alias_resolver=resolver)
+        registry.register(ExecutorDefinition(
+            id="test.a",
+            name="A",
+            kind="built_in",
+            version="1.0",
+            graph=GraphMetadata(depends_on=("test.dep_alias",)),
+        ))
+        registry.register(ExecutorDefinition(
+            id="test.b",
+            name="B",
+            kind="built_in",
+            version="1.0",
+        ))
+
+        # Should not raise
+        registry.validate_all()
+
+    def test_depends_on_alias_resolves_to_unknown_executor_fails(self) -> None:
+        """Executor A depends on alias 'test.dep_alias' which maps to
+        an executor not in the registry. Validation should fail."""
+        from astrid.core.executor.registry import ExecutorRegistry, ExecutorRegistryError
+        from astrid.core.executor.schema import ExecutorDefinition, GraphMetadata
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.dep_alias", "test.missing")
+
+        registry = ExecutorRegistry(alias_resolver=resolver)
+        registry.register(ExecutorDefinition(
+            id="test.a",
+            name="A",
+            kind="built_in",
+            version="1.0",
+            graph=GraphMetadata(depends_on=("test.dep_alias",)),
+        ))
+
+        with pytest.raises(ExecutorRegistryError, match="depends on unknown executor"):
+            registry.validate_all()
+
+    def test_depends_on_alias_chained_resolves_correctly(self) -> None:
+        """Executor A depends on 'test.chain_a' → 'test.chain_b' → 'test.c'.
+        Validation should resolve the chain and succeed."""
+        from astrid.core.executor.registry import ExecutorRegistry
+        from astrid.core.executor.schema import ExecutorDefinition, GraphMetadata
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.chain_a", "test.chain_b")
+        resolver.register_alias("test.chain_b", "test.c")
+
+        registry = ExecutorRegistry(alias_resolver=resolver)
+        registry.register(ExecutorDefinition(
+            id="test.a",
+            name="A",
+            kind="built_in",
+            version="1.0",
+            graph=GraphMetadata(depends_on=("test.chain_a",)),
+        ))
+        registry.register(ExecutorDefinition(
+            id="test.c",
+            name="C",
+            kind="built_in",
+            version="1.0",
+        ))
+
+        registry.validate_all()
+
+    def test_depends_on_without_alias_resolver_falls_back_to_raw_id(self) -> None:
+        """When no alias resolver is set, depends_on IDs are used as-is."""
+        from astrid.core.executor.registry import ExecutorRegistry
+        from astrid.core.executor.schema import ExecutorDefinition, GraphMetadata
+
+        registry = ExecutorRegistry()
+        registry.register(ExecutorDefinition(
+            id="test.a",
+            name="A",
+            kind="built_in",
+            version="1.0",
+            graph=GraphMetadata(depends_on=("test.b",)),
+        ))
+        registry.register(ExecutorDefinition(
+            id="test.b",
+            name="B",
+            kind="built_in",
+            version="1.0",
+        ))
+
+        registry.validate_all()
+
+    def test_depends_on_self_reference_via_alias_fails(self) -> None:
+        """Executor A depends on alias 'test.self_alias' which maps to 'test.a'.
+        Validation should detect the self-reference."""
+        from astrid.core.executor.registry import ExecutorRegistry, ExecutorRegistryError
+        from astrid.core.executor.schema import ExecutorDefinition, GraphMetadata
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.self_alias", "test.a")
+
+        registry = ExecutorRegistry(alias_resolver=resolver)
+        registry.register(ExecutorDefinition(
+            id="test.a",
+            name="A",
+            kind="built_in",
+            version="1.0",
+            graph=GraphMetadata(depends_on=("test.self_alias",)),
+        ))
+
+        with pytest.raises(ExecutorRegistryError, match="cannot depend on itself"):
+            registry.validate_all()
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator child_orchestrators alias resolution (integration)
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorChildOrchestratorAliasResolution:
+    """Tests that OrchestratorRegistry._validate_child_orchestrators
+    resolves aliases in child_orchestrators before checking existence."""
+
+    def test_child_orchestrator_alias_resolves_to_known_orchestrator(self) -> None:
+        """Orchestrator A declares child orchestrator alias 'test.child_alias'
+        which maps to 'test.b'. Validation should succeed."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.child_alias", "test.b")
+
+        orch_reg = OrchestratorRegistry(
+            executor_registry=ExecutorRegistry(),
+            alias_resolver=resolver,
+        )
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.child_alias",),
+        ))
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.b",
+        ))
+
+        orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+    def test_child_orchestrator_alias_resolves_to_unknown_fails(self) -> None:
+        """Orchestrator A declares child orchestrator alias that maps to
+        an unknown orchestrator. Validation should fail."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.child_alias", "test.missing")
+
+        orch_reg = OrchestratorRegistry(
+            executor_registry=ExecutorRegistry(),
+            alias_resolver=resolver,
+        )
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.child_alias",),
+        ))
+
+        with pytest.raises(OrchestratorRegistryError, match="unknown child orchestrator"):
+            orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+    def test_child_orchestrator_alias_chained_resolves_correctly(self) -> None:
+        """Orchestrator A → alias chain → test.c. Validation should succeed."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.chain_a", "test.chain_b")
+        resolver.register_alias("test.chain_b", "test.c")
+
+        orch_reg = OrchestratorRegistry(
+            executor_registry=ExecutorRegistry(),
+            alias_resolver=resolver,
+        )
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.chain_a",),
+        ))
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.c",
+        ))
+
+        orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+    def test_child_orchestrator_self_reference_via_alias_fails(self) -> None:
+        """Orchestrator A declares child orchestrator alias that maps to
+        test.a itself. Validation should detect the self-reference."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.self_alias", "test.a")
+
+        orch_reg = OrchestratorRegistry(
+            executor_registry=ExecutorRegistry(),
+            alias_resolver=resolver,
+        )
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.self_alias",),
+        ))
+
+        with pytest.raises(OrchestratorRegistryError, match="cannot reference itself"):
+            orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+    def test_child_orchestrator_without_alias_resolver_falls_back_to_raw_id(self) -> None:
+        """When no alias resolver is set, child_orchestrator IDs are used as-is."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        orch_reg = OrchestratorRegistry(executor_registry=ExecutorRegistry())
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.b",),
+        ))
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.b",
+        ))
+
+        orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+    def test_child_orchestrator_alias_cycle_detected(self) -> None:
+        """A → alias(B) → B → alias(A) should detect a cycle across aliases."""
+        from astrid.core.executor.registry import ExecutorRegistry
+
+        resolver = AliasResolver()
+        resolver.register_alias("test.alias_a", "test.a")
+        resolver.register_alias("test.alias_b", "test.b")
+
+        orch_reg = OrchestratorRegistry(
+            executor_registry=ExecutorRegistry(),
+            alias_resolver=resolver,
+        )
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.a",
+            child_orchestrators=("test.alias_b",),
+        ))
+        orch_reg.register(_make_minimal_orchestrator(
+            id="test.b",
+            child_orchestrators=("test.alias_a",),
+        ))
+
+        with pytest.raises(OrchestratorRegistryError, match="cycle"):
+            orch_reg.validate_all(executor_registry=ExecutorRegistry())
+
+
+# ---------------------------------------------------------------------------
+# Temp-pack manifest integration: pack.yaml aliases → registry loading
+# ---------------------------------------------------------------------------
+
+class TestTempPackAliasIntegration:
+    """Full integration tests that create temp packs with pack.yaml aliases,
+    executor.yaml / orchestrator.yaml manifests, then load default registries
+    and verify alias resolution, override behavior, and missing-target errors."""
+
+    def test_pack_yaml_aliases_flow_into_executor_registry_lookup(self) -> None:
+        """Create a temp pack with pack.yaml aliases (kind: executor) and an
+        executor.yaml. Load the executor registry and verify:
+        - alias resolves to the canonical executor
+        - get() via the alias returns the canonical definition
+        - get() via the canonical id also works
+        - alias metadata (deprecated, deprecation_message) is preserved
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.old_runner",
+                    "    canonical_id: testpack.runner",
+                    "    deprecated: true",
+                    "    deprecation_message: Use testpack.runner instead",
+                    "  - kind: orchestrator",
+                    "    alias: testpack.old_flow",
+                    "    canonical_id: testpack.flow",
+                ]),
+            )
+            _write_executor(pack_root, "runner", "testpack.runner")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # Direct lookup via canonical id
+            canonical = registry.get("testpack.runner")
+            assert canonical.id == "testpack.runner"
+
+            # Alias lookup
+            aliased = registry.get("testpack.old_runner")
+            assert aliased.id == "testpack.runner"
+
+            # Alias metadata: enrich handle via resolver (same pattern as CLI _cmd_inspect)
+            handle = to_capability_handle(aliased)
+            resolver = registry.alias_resolver
+            assert resolver is not None
+            handle_aliases = resolver.get_aliases_for(aliased.id)
+            assert len(handle_aliases) == 1
+            assert handle_aliases[0].alias == "testpack.old_runner"
+            assert handle_aliases[0].deprecated is True
+            assert handle_aliases[0].deprecation_message == "Use testpack.runner instead"
+
+            # Orchestrator aliases should NOT be in the executor resolver
+            assert registry.alias_resolver.is_alias("testpack.old_flow") is False
+
+    def test_pack_yaml_aliases_flow_into_orchestrator_registry_lookup(self) -> None:
+        """Create a temp pack with pack.yaml aliases (kind: orchestrator) and an
+        orchestrator.yaml. Load the orchestrator registry and verify alias
+        resolution and metadata preservation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.old_runner",
+                    "    canonical_id: testpack.runner",
+                    "  - kind: orchestrator",
+                    "    alias: testpack.old_flow",
+                    "    canonical_id: testpack.flow",
+                    "    deprecated: true",
+                    "    deprecation_message: Use testpack.flow instead",
+                ]),
+            )
+            _write_orchestrator(pack_root, "flow", "testpack.flow")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+            # Direct lookup via canonical id
+            canonical = registry.get("testpack.flow")
+            assert canonical.id == "testpack.flow"
+
+            # Alias lookup
+            aliased = registry.get("testpack.old_flow")
+            assert aliased.id == "testpack.flow"
+
+            # Alias metadata: enrich handle via resolver (same pattern as CLI _cmd_inspect)
+            handle = orch_to_capability_handle(aliased)
+            resolver = registry.alias_resolver
+            assert resolver is not None
+            handle_aliases = resolver.get_aliases_for(aliased.id)
+            assert len(handle_aliases) == 1
+            assert handle_aliases[0].alias == "testpack.old_flow"
+            assert handle_aliases[0].deprecated is True
+
+            # Executor aliases should NOT be in the orchestrator resolver
+            assert registry.alias_resolver is not None
+            assert registry.alias_resolver.is_alias("testpack.old_runner") is False
+
+    def test_pack_yaml_alias_missing_canonical_target_raises_on_get(self) -> None:
+        """Pack declares an executor alias whose canonical_id does not exist
+        in the registry. get() via the alias should raise KeyError.
+        
+        We bypass load_default_registry (which calls validate_all) and
+        construct a registry manually so we can test get() semantics directly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.ghost",
+                    "    canonical_id: testpack.nonexistent",
+                ]),
+            )
+            # Note: no executor.yaml for testpack.nonexistent
+            packs = discover_packs(packs_root)
+
+            # Manually build a registry with the pack aliases but skip validate_all
+            resolver = AliasResolver()
+            _register_pack_aliases(resolver, extract_pack_aliases(packs, kind="executor"))
+            registry = ExecutorRegistry(alias_resolver=resolver)
+
+            with pytest.raises(KeyError, match="alias.*points to missing executor"):
+                registry.get("testpack.ghost")
+
+    def test_pack_yaml_alias_with_override_resolves_override_target(self) -> None:
+        """Pack declares an executor alias to canonical A. Override maps
+        canonical A → B. get() via alias should return B's definition."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.old_runner",
+                    "    canonical_id: testpack.runner",
+                ]),
+            )
+            _write_executor(pack_root, "runner", "testpack.runner")
+            # Also add a local-like executor to simulate override target
+            local_root = packs_root / "local"
+            local_root.mkdir(parents=True, exist_ok=True)
+            _write_executor(local_root, "runner", "local.runner")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # Manually register the override target (since it may not be
+            # auto-discovered in this temp structure)
+            from astrid.core.executor.schema import ExecutorDefinition
+            registry.register(ExecutorDefinition(
+                id="local.runner",
+                name="Local Runner",
+                kind="built_in",
+                version="2.0",
+                metadata={"source": "pack", "source_pack": "local"},
+            ))
+
+            # Set override: testpack.runner → local.runner
+            override_store = OverrideStore(project_root=tmp)
+            override_store.set_override("executor", "testpack.runner", "local.runner")
+            registry.override_store = override_store
+
+            # Alias lookup should resolve: alias → canonical → override
+            result = registry.get("testpack.old_runner")
+            assert result.id == "local.runner"
+            assert result.name == "Local Runner"
+
+    def test_pack_yaml_both_kinds_with_executor_and_orchestrator_in_same_pack(self) -> None:
+        """A single pack declares both executor and orchestrator aliases
+        alongside both executor.yaml and orchestrator.yaml. Both registries
+        should load only their respective kind-filtered aliases."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "dualpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: dualpack.old_run",
+                    "    canonical_id: dualpack.run",
+                    "  - kind: orchestrator",
+                    "    alias: dualpack.old_flow",
+                    "    canonical_id: dualpack.flow",
+                ]),
+            )
+            _write_executor(pack_root, "run", "dualpack.run")
+            _write_orchestrator(pack_root, "flow", "dualpack.flow")
+            packs = discover_packs(packs_root)
+
+            # Load executor registry
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                exec_reg = load_executor_registry()
+            assert exec_reg.alias_resolver.resolve("dualpack.old_run") == "dualpack.run"
+            assert not exec_reg.alias_resolver.is_alias("dualpack.old_flow")
+
+            # Load orchestrator registry
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                orch_reg = load_orchestrator_registry()
+            assert orch_reg.alias_resolver.resolve("dualpack.old_flow") == "dualpack.flow"
+            assert not orch_reg.alias_resolver.is_alias("dualpack.old_run")
+
+    def test_pack_yaml_aliases_preserve_source_pack_id_in_handle(self) -> None:
+        """Verify that source_pack_id is carried through from pack.yaml alias
+        declarations into the resolver records."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "srcpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: srcpack.legacy",
+                    "    canonical_id: srcpack.main",
+                ]),
+            )
+            _write_executor(pack_root, "main", "srcpack.main")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            result = registry.get("srcpack.legacy")
+            assert result.id == "srcpack.main"
+            # The source_pack_id is stored in the resolver record
+            assert registry.alias_resolver is not None
+            resolver_aliases = registry.alias_resolver.get_aliases_for("srcpack.main")
+            assert len(resolver_aliases) == 1
+            assert resolver_aliases[0].source_pack_id == "srcpack"
+
+    def test_pack_yaml_alias_to_alias_chain_in_same_pack(self) -> None:
+        """Pack declares alias A→B and B→C. Loading through pack.yaml should
+        register both and resolve A to C through the chain."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "chainpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: chainpack.v1",
+                    "    canonical_id: chainpack.v2",
+                    "  - kind: executor",
+                    "    alias: chainpack.v2",
+                    "    canonical_id: chainpack.v3",
+                ]),
+            )
+            _write_executor(pack_root, "v3", "chainpack.v3")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # v1 → v2 → v3
+            result = registry.get("chainpack.v1")
+            assert result.id == "chainpack.v3"
+
+    def test_pack_yaml_empty_aliases_still_loads_registry(self) -> None:
+        """Pack with no aliases declared should still load normally without
+        breaking the registry."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(packs_root, "cleanpack")
+            _write_executor(pack_root, "main", "cleanpack.main")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            result = registry.get("cleanpack.main")
+            assert result.id == "cleanpack.main"
+            # Should still have an empty alias resolver
+            assert registry.alias_resolver is not None
+            assert len(registry.alias_resolver._aliases) == 0
+
+
+# ---------------------------------------------------------------------------
+# T10: Search alias visibility — aliases field in search records
+# ---------------------------------------------------------------------------
+
+
+class TestAliasSearchRecords:
+    """Search record builders include alias ids in the fields dict so that
+    alias terms score against canonical capabilities without duplicate hits."""
+
+    def test_executor_search_record_includes_alias_field(self) -> None:
+        """_executor_search_record puts alias text into fields['aliases']."""
+        from astrid.core.executor.cli import _executor_search_record
+        from astrid.core.executor.schema import ExecutorDefinition
+
+        definition = ExecutorDefinition(
+            id="testpack.runner",
+            name="Runner",
+            kind="built_in",
+            version="1.0",
+            command={"argv": ["echo", "ok"]},
+            cache={"mode": "none"},
+        )
+        record = _executor_search_record(definition, aliases="testpack.old_runner [deprecated] Use testpack.runner")
+        assert record.fields.get("aliases") == "testpack.old_runner [deprecated] Use testpack.runner"
+
+    def test_executor_search_record_omits_aliases_when_empty(self) -> None:
+        """_executor_search_record does not include 'aliases' key when empty."""
+        from astrid.core.executor.cli import _executor_search_record
+        from astrid.core.executor.schema import ExecutorDefinition
+
+        definition = ExecutorDefinition(
+            id="testpack.runner",
+            name="Runner",
+            kind="built_in",
+            version="1.0",
+            command={"argv": ["echo", "ok"]},
+            cache={"mode": "none"},
+        )
+        record = _executor_search_record(definition)  # default aliases=""
+        assert "aliases" not in record.fields
+
+    def test_orchestrator_search_record_includes_alias_field(self) -> None:
+        """_orchestrator_search_record puts alias text into fields['aliases']."""
+        from astrid.core.orchestrator.cli import _orchestrator_search_record
+        from astrid.core.orchestrator.schema import OrchestratorDefinition, RuntimeSpec
+
+        definition = OrchestratorDefinition(
+            id="testpack.flow",
+            name="Flow",
+            kind="built_in",
+            version="1.0",
+            runtime=RuntimeSpec(kind="command", command={"command": ["echo", "ok"]}),
+        )
+        record = _orchestrator_search_record(definition, aliases="testpack.old_flow [deprecated] Use testpack.flow")
+        assert record.fields.get("aliases") == "testpack.old_flow [deprecated] Use testpack.flow"
+
+    def test_search_scoring_matches_alias_field(self) -> None:
+        """search() matches terms found in the 'aliases' field of a record."""
+        from astrid.core._search import SearchRecord, FIELD_WEIGHTS, search
+
+        assert "aliases" in FIELD_WEIGHTS
+        assert FIELD_WEIGHTS["aliases"] == 3.0
+
+        record = SearchRecord(
+            id="testpack.runner",
+            kind="executor",
+            short_description="A runner",
+            fields={
+                "id": "testpack.runner",
+                "name": "Runner",
+                "short_description": "A runner",
+                "description": "Does stuff",
+                "keywords": "run execute",
+                "aliases": "testpack.old_runner [deprecated] Use testpack.runner instead",
+            },
+        )
+
+        # Searching by the alias id should find the canonical record
+        hits = search([record], ["old_runner"])
+        assert len(hits) == 1
+        assert hits[0].record.id == "testpack.runner"
+        assert hits[0].score > 0
+
+    def test_search_alias_does_not_produce_duplicate_hits(self) -> None:
+        """Searching by an alias term returns exactly one hit — the canonical
+        capability, not a separate alias record."""
+        from astrid.core._search import SearchRecord, search
+
+        canonical = SearchRecord(
+            id="testpack.runner",
+            kind="executor",
+            short_description="A runner",
+            fields={
+                "id": "testpack.runner",
+                "name": "Runner",
+                "short_description": "A runner",
+                "description": "Does things",
+                "keywords": "run execute",
+                "aliases": "testpack.old_runner",
+            },
+        )
+
+        # No separate alias record is emitted
+        hits = search([canonical], ["old_runner"])
+        assert len(hits) == 1
+        assert hits[0].record.id == "testpack.runner"
+
+
+class TestSearchAliasIntegration:
+    """Integration: temp pack with aliases → registry → search records."""
+
+    def test_pack_yaml_aliases_appear_in_executor_search_record_fields(self) -> None:
+        """Create a temp pack with an executor alias, load the registry, and
+        verify the alias id appears in the search record fields['aliases']."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.old_runner",
+                    "    canonical_id: testpack.runner",
+                    "    deprecated: true",
+                    "    deprecation_message: Use testpack.runner instead",
+                ]),
+            )
+            _write_executor(pack_root, "runner", "testpack.runner")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            from astrid.core.executor.cli import _executor_search_record, _aliases_text
+
+            resolver = registry.alias_resolver
+            assert resolver is not None
+
+            for executor in registry.list():
+                aliases = _aliases_text(resolver, executor.id)
+                record = _executor_search_record(executor, aliases=aliases)
+                if executor.id == "testpack.runner":
+                    assert "aliases" in record.fields
+                    assert "testpack.old_runner" in record.fields["aliases"]
+                    assert "[deprecated]" in record.fields["aliases"]
+                    assert "Use testpack.runner instead" in record.fields["aliases"]
+                else:
+                    # Other executors should not have the old_runner alias
+                    assert "testpack.old_runner" not in record.fields.get("aliases", "")
+
+    def test_pack_yaml_aliases_appear_in_orchestrator_search_record_fields(self) -> None:
+        """Create a temp pack with an orchestrator alias, load the registry, and
+        verify the alias id appears in the search record fields['aliases']."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: orchestrator",
+                    "    alias: testpack.old_flow",
+                    "    canonical_id: testpack.flow",
+                    "    deprecated: true",
+                    "    deprecation_message: Use testpack.flow instead",
+                ]),
+            )
+            _write_orchestrator(pack_root, "flow", "testpack.flow")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+            from astrid.core.orchestrator.cli import _orchestrator_search_record, _aliases_text
+
+            resolver = registry.alias_resolver
+            assert resolver is not None
+
+            for orchestrator in registry.list():
+                aliases = _aliases_text(resolver, orchestrator.id)
+                record = _orchestrator_search_record(orchestrator, aliases=aliases)
+                if orchestrator.id == "testpack.flow":
+                    assert "aliases" in record.fields
+                    assert "testpack.old_flow" in record.fields["aliases"]
+                    assert "[deprecated]" in record.fields["aliases"]
+                    assert "Use testpack.flow instead" in record.fields["aliases"]
+                else:
+                    # Other orchestrators should not have the old_flow alias
+                    assert "testpack.old_flow" not in record.fields.get("aliases", "")
+
+    def test_search_by_alias_returns_canonical_no_duplicates(self) -> None:
+        """End-to-end: temp pack with alias → load registry → search by alias
+        via _cmd_search → single canonical hit, no duplicate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = _write_pack(
+                packs_root,
+                "testpack",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: testpack.old_runner",
+                    "    canonical_id: testpack.runner",
+                ]),
+            )
+            _write_executor(pack_root, "runner", "testpack.runner")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # Build search records using the same logic as _cmd_search
+            from astrid.core.executor.cli import _executor_search_record, _aliases_text
+            from astrid.core._search import search as run_search
+
+            resolver = registry.alias_resolver
+            assert resolver is not None
+
+            records = [
+                _executor_search_record(
+                    executor,
+                    aliases=_aliases_text(resolver, executor.id),
+                )
+                for executor in registry.list()
+            ]
+
+            # Search by the alias — should return the canonical capability
+            hits = run_search(records, ["old_runner"])
+            assert len(hits) == 1
+            assert hits[0].record.id == "testpack.runner"
+
+            # Search by canonical id should also work
+            hits2 = run_search(records, ["testpack.runner"])
+            assert len(hits2) >= 1
+            assert any(h.record.id == "testpack.runner" for h in hits2)
+
+
+# ---------------------------------------------------------------------------
+# T11: Representative migrated-pack fixtures — deprecated old ids that
+# resolve to new canonical ids via pack.yaml aliases.  These temp-pack
+# tests prove the migration path (builtin.render → rendering.render,
+# external.vibecomfy.run → vibecomfy.run, etc.) without moving any real
+# source-tree capability files.
+# ---------------------------------------------------------------------------
+
+
+class TestMigratedPackAliasFixtures:
+    """T11: Temp-pack fixtures for representative canonical ids and their
+    deprecated aliases.  Covers registry lookup, CLI inspect JSON, and
+    human-readable inspect output — all using temporary directories, so
+    no real ``builtin``, ``external``, or ``upload`` files are touched.
+    """
+
+    # -- helpers (largely mirror the module-level helpers but let us
+    #    keep the new test class self-contained) --------------------------
+
+    @staticmethod
+    def _write_pack(root: Path, pack_id: str, aliases: str = "") -> Path:
+        pack_root = root / pack_id
+        pack_root.mkdir(parents=True)
+        lines = [
+            "schema_version: 1",
+            f"id: {pack_id}",
+            f"name: {pack_id.title()} Pack",
+            "version: '1.0'",
+        ]
+        if aliases:
+            lines.append("aliases:")
+            lines.extend(aliases.splitlines())
+        (pack_root / "pack.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return pack_root
+
+    @staticmethod
+    def _write_executor(pack_root: Path, folder: str, executor_id: str) -> None:
+        root = pack_root / folder
+        root.mkdir()
+        (root / "executor.yaml").write_text(
+            "\n".join([
+                f"id: {executor_id}",
+                f"name: {executor_id}",
+                "kind: built_in",
+                "version: '1.0'",
+                "command:",
+                "  argv: ['echo', 'ok']",
+                "cache:",
+                "  mode: none",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _write_orchestrator(pack_root: Path, folder: str, orch_id: str) -> None:
+        root = pack_root / folder
+        root.mkdir()
+        (root / "orchestrator.yaml").write_text(
+            "\n".join([
+                f"id: {orch_id}",
+                f"name: {orch_id}",
+                "kind: built_in",
+                "version: '1.0'",
+                "runtime:",
+                "  kind: command",
+                "  command:",
+                "    argv: ['echo', 'ok']",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+    # -- registry lookup via deprecated alias -----------------------------
+
+    def test_deprecated_alias_builtin_render_resolves_to_rendering_render(self) -> None:
+        """``builtin.render`` (deprecated) → ``rendering.render`` (canonical)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "rendering",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.render",
+                    "    canonical_id: rendering.render",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to rendering.render",
+                ]),
+            )
+            self._write_executor(pack_root, "render", "rendering.render")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # Old alias lookup
+            result = registry.get("builtin.render")
+            assert result.id == "rendering.render"
+
+            # Resolver metadata
+            assert registry.alias_resolver is not None
+            record = registry.alias_resolver.get_record("builtin.render")
+            assert record.canonical_id == "rendering.render"
+            assert record.deprecated is True
+            assert record.deprecation_message == "Moved to rendering.render"
+            assert record.source_pack_id == "rendering"
+
+    def test_deprecated_alias_external_vibecomfy_run_resolves_to_vibecomfy_run(self) -> None:
+        """``external.vibecomfy.run`` (deprecated) → ``vibecomfy.run`` (canonical)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "vibecomfy",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: external.vibecomfy.run",
+                    "    canonical_id: vibecomfy.run",
+                    "    deprecated: true",
+                    "    deprecation_message: Use vibecomfy.run directly",
+                ]),
+            )
+            self._write_executor(pack_root, "run", "vibecomfy.run")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            result = registry.get("external.vibecomfy.run")
+            assert result.id == "vibecomfy.run"
+
+            assert registry.alias_resolver is not None
+            record = registry.alias_resolver.get_record("external.vibecomfy.run")
+            assert record.canonical_id == "vibecomfy.run"
+            assert record.deprecated is True
+            assert record.deprecation_message == "Use vibecomfy.run directly"
+            assert record.source_pack_id == "vibecomfy"
+
+    def test_orchestrator_alias_builtin_hype_resolves_to_video_editing_hype(self) -> None:
+        """``builtin.hype`` (deprecated) → ``video_editing.hype`` (canonical)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "video_editing",
+                aliases="\n".join([
+                    "  - kind: orchestrator",
+                    "    alias: builtin.hype",
+                    "    canonical_id: video_editing.hype",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to video_editing.hype",
+                ]),
+            )
+            self._write_orchestrator(pack_root, "hype", "video_editing.hype")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+            result = registry.get("builtin.hype")
+            assert result.id == "video_editing.hype"
+
+            assert registry.alias_resolver is not None
+            record = registry.alias_resolver.get_record("builtin.hype")
+            assert record.canonical_id == "video_editing.hype"
+            assert record.deprecated is True
+
+    def test_media_transcribe_alias_to_canonical_executor(self) -> None:
+        """``builtin.transcribe`` (non-deprecated alias) → ``media.transcribe``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "media",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.transcribe",
+                    "    canonical_id: media.transcribe",
+                ]),
+            )
+            self._write_executor(pack_root, "transcribe", "media.transcribe")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            result = registry.get("builtin.transcribe")
+            assert result.id == "media.transcribe"
+
+            assert registry.alias_resolver is not None
+            record = registry.alias_resolver.get_record("builtin.transcribe")
+            assert record.canonical_id == "media.transcribe"
+            assert record.deprecated is False
+
+    # -- CLI inspect: JSON output with alias/deprecation metadata ---------
+
+    def test_executor_inspect_json_via_deprecated_alias_returns_canonical_with_metadata(self) -> None:
+        """Executing ``executors inspect builtin.render --json`` against a
+        temp pack whose pack.yaml declares ``builtin.render → rendering.render``
+        should return the canonical definition and carry alias + deprecation
+        metadata in the ``_capability`` block."""
+        with tempfile.TemporaryDirectory() as tmp:
+            from astrid.core.executor.cli import _cmd_inspect
+            import io, contextlib, json as _json, argparse
+
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "rendering",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.render",
+                    "    canonical_id: rendering.render",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to rendering.render",
+                ]),
+            )
+            self._write_executor(pack_root, "render", "rendering.render")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            inspect_stdout = io.StringIO()
+            with contextlib.redirect_stdout(inspect_stdout):
+                rc = _cmd_inspect(
+                    argparse.Namespace(
+                        executor_id="builtin.render",
+                        json=True,
+                        pack=None,
+                        show_overrides=False,
+                    ),
+                    registry,
+                )
+            assert rc == 0
+            payload = _json.loads(inspect_stdout.getvalue())
+
+            # Canonical definition
+            assert payload["id"] == "rendering.render"
+
+            # _capability block
+            cap = payload["_capability"]
+            assert cap["canonical_id"] == "rendering.render"
+            assert cap["provenance"]["resolved_alias"] == "builtin.render"
+            assert cap["deprecated"] is True
+            assert cap["deprecation_message"] == "Moved to rendering.render"
+            assert len(cap["aliases"]) >= 1
+            alias_ids = [a["alias"] for a in cap["aliases"]]
+            assert "builtin.render" in alias_ids
+
+            # Definition metadata must NOT be mutated
+            assert "resolved_alias" not in payload.get("metadata", {})
+            assert "deprecated" not in payload.get("metadata", {})
+
+    def test_orchestrator_inspect_json_via_deprecated_alias_returns_canonical_with_metadata(self) -> None:
+        """Executing ``orchestrators inspect builtin.hype --json`` against a
+        temp pack whose pack.yaml declares ``builtin.hype → video_editing.hype``
+        should return the canonical definition and carry alias + deprecation
+        metadata in the ``_capability`` block."""
+        with tempfile.TemporaryDirectory() as tmp:
+            from astrid.core.orchestrator.cli import _cmd_inspect
+            import io, contextlib, json as _json, argparse
+
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "video_editing",
+                aliases="\n".join([
+                    "  - kind: orchestrator",
+                    "    alias: builtin.hype",
+                    "    canonical_id: video_editing.hype",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to video_editing.hype",
+                ]),
+            )
+            self._write_orchestrator(pack_root, "hype", "video_editing.hype")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+            inspect_stdout = io.StringIO()
+            with contextlib.redirect_stdout(inspect_stdout):
+                rc = _cmd_inspect(
+                    argparse.Namespace(
+                        orchestrator_id="builtin.hype",
+                        json=True,
+                        pack=None,
+                        show_overrides=False,
+                    ),
+                    registry,
+                )
+            assert rc == 0
+            payload = _json.loads(inspect_stdout.getvalue())
+
+            # Canonical definition
+            assert payload["id"] == "video_editing.hype"
+
+            # _capability block
+            cap = payload["_capability"]
+            assert cap["canonical_id"] == "video_editing.hype"
+            assert cap["provenance"]["resolved_alias"] == "builtin.hype"
+            assert cap["deprecated"] is True
+            assert cap["deprecation_message"] == "Moved to video_editing.hype"
+            assert len(cap["aliases"]) >= 1
+            alias_ids = [a["alias"] for a in cap["aliases"]]
+            assert "builtin.hype" in alias_ids
+
+            # Definition metadata must NOT be mutated
+            assert "resolved_alias" not in payload.get("metadata", {})
+
+    # -- CLI inspect: human-readable output with alias/deprecation --------
+
+    def test_executor_inspect_human_readable_shows_alias_mapping_and_deprecation(self) -> None:
+        """Human-readable ``executors inspect`` on a deprecated alias prints
+        ``requested_alias`` and ``deprecated`` lines."""
+        with tempfile.TemporaryDirectory() as tmp:
+            from astrid.core.executor.cli import _cmd_inspect
+            import io, contextlib, argparse
+
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "rendering",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.render",
+                    "    canonical_id: rendering.render",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to rendering.render",
+                ]),
+            )
+            self._write_executor(pack_root, "render", "rendering.render")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            inspect_stdout = io.StringIO()
+            with contextlib.redirect_stdout(inspect_stdout):
+                rc = _cmd_inspect(
+                    argparse.Namespace(
+                        executor_id="builtin.render",
+                        json=False,
+                        pack=None,
+                        show_overrides=False,
+                    ),
+                    registry,
+                )
+            assert rc == 0
+            output = inspect_stdout.getvalue()
+
+            assert "id: rendering.render" in output
+            assert "requested_alias: builtin.render → rendering.render" in output
+            assert "deprecated: Moved to rendering.render" in output
+
+    def test_orchestrator_inspect_human_readable_shows_alias_mapping_and_deprecation(self) -> None:
+        """Human-readable ``orchestrators inspect`` on a deprecated alias prints
+        ``requested_alias`` and ``deprecated`` lines."""
+        with tempfile.TemporaryDirectory() as tmp:
+            from astrid.core.orchestrator.cli import _cmd_inspect
+            import io, contextlib, argparse
+
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "video_editing",
+                aliases="\n".join([
+                    "  - kind: orchestrator",
+                    "    alias: builtin.hype",
+                    "    canonical_id: video_editing.hype",
+                    "    deprecated: true",
+                    "    deprecation_message: Moved to video_editing.hype",
+                ]),
+            )
+            self._write_orchestrator(pack_root, "hype", "video_editing.hype")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                registry = load_orchestrator_registry()
+
+            inspect_stdout = io.StringIO()
+            with contextlib.redirect_stdout(inspect_stdout):
+                rc = _cmd_inspect(
+                    argparse.Namespace(
+                        orchestrator_id="builtin.hype",
+                        json=False,
+                        pack=None,
+                        show_overrides=False,
+                    ),
+                    registry,
+                )
+            assert rc == 0
+            output = inspect_stdout.getvalue()
+
+            assert "id: video_editing.hype" in output
+            assert "requested_alias: builtin.hype → video_editing.hype" in output
+            assert "deprecated: Moved to video_editing.hype" in output
+
+    # -- Mixed pack: executor + orchestrator aliases in one pack ----------
+
+    def test_mixed_pack_with_both_executor_and_orchestrator_migrated_aliases(self) -> None:
+        """A single temp pack declares both executor and orchestrator aliases
+        with migration semantics.  Both registries load only their kind-filtered
+        aliases and resolve canonical ids correctly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "migrated",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.render",
+                    "    canonical_id: migrated.render",
+                    "    deprecated: true",
+                    "  - kind: orchestrator",
+                    "    alias: builtin.hype",
+                    "    canonical_id: migrated.hype",
+                    "    deprecated: true",
+                ]),
+            )
+            self._write_executor(pack_root, "render", "migrated.render")
+            self._write_orchestrator(pack_root, "hype", "migrated.hype")
+            packs = discover_packs(packs_root)
+
+            # Executor registry
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                exec_reg = load_executor_registry()
+            result = exec_reg.get("builtin.render")
+            assert result.id == "migrated.render"
+            assert not exec_reg.alias_resolver.is_alias("builtin.hype")
+
+            # Orchestrator registry
+            with mock.patch("astrid.core.orchestrator.registry.discover_packs", return_value=packs):
+                orch_reg = load_orchestrator_registry()
+            result2 = orch_reg.get("builtin.hype")
+            assert result2.id == "migrated.hype"
+            assert not orch_reg.alias_resolver.is_alias("builtin.render")
+
+    # -- Multiple aliases for one canonical id ----------------------------
+
+    def test_multiple_deprecated_aliases_for_same_canonical(self) -> None:
+        """Multiple old ids all resolve to the same canonical id."""
+        with tempfile.TemporaryDirectory() as tmp:
+            packs_root = Path(tmp) / "packs"
+            pack_root = self._write_pack(
+                packs_root,
+                "rendering",
+                aliases="\n".join([
+                    "  - kind: executor",
+                    "    alias: builtin.render",
+                    "    canonical_id: rendering.render",
+                    "    deprecated: true",
+                    "  - kind: executor",
+                    "    alias: old.render",
+                    "    canonical_id: rendering.render",
+                    "    deprecated: true",
+                    "  - kind: executor",
+                    "    alias: legacy.render",
+                    "    canonical_id: rendering.render",
+                ]),
+            )
+            self._write_executor(pack_root, "render", "rendering.render")
+            packs = discover_packs(packs_root)
+
+            with mock.patch("astrid.core.executor.registry.discover_packs", return_value=packs):
+                registry = load_executor_registry()
+
+            # All three aliases resolve to the same canonical
+            for alias_id in ("builtin.render", "old.render", "legacy.render"):
+                result = registry.get(alias_id)
+                assert result.id == "rendering.render", f"Alias {alias_id} did not resolve correctly"
+
+            # get_aliases_for lists all three
+            assert registry.alias_resolver is not None
+            aliases = registry.alias_resolver.get_aliases_for("rendering.render")
+            alias_ids = {a.alias for a in aliases}
+            assert alias_ids == {"builtin.render", "old.render", "legacy.render"}
+
+    # -- Guard: no real builtin/external/upload files are touched ---------
+
+    def test_no_real_builtin_external_or_upload_files_are_moved(self) -> None:
+        """Assert that the real source-tree directories for ``builtin``,
+        ``external``, and ``upload`` packs still exist at their original
+        paths, proving these temp-pack fixture tests did not move or
+        delete any real capability files."""
+        import os
+        repo_root = Path(__file__).resolve().parents[1]
+        for pack_name in ("builtin", "external", "upload"):
+            pack_path = repo_root / "astrid" / "packs" / pack_name
+            assert pack_path.is_dir(), (
+                f"Real pack directory {pack_path} is missing — "
+                f"temp-pack fixture tests must not move real source-tree files"
+            )
+            # At minimum the pack.yaml should still exist
+            pack_yaml = pack_path / "pack.yaml"
+            assert pack_yaml.is_file(), (
+                f"pack.yaml missing from {pack_path} — "
+                f"temp-pack fixture tests must not alter real pack manifests"
+            )

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -217,7 +217,7 @@ class TestOverrideStoreRegistryIntegration:
             # The override routes builtin.shots → local.shots
             assert result.id == "local.shots"
             assert result.name == "Local Shots"
-            assert result.metadata["override_target"] == "local.shots"
+            assert "override_target" not in result.metadata
 
     def test_executor_registry_get_no_override_returns_winner(self):
         """Without override, get() returns the priority winner."""

--- a/tests/test_pack_yaml_schema.py
+++ b/tests/test_pack_yaml_schema.py
@@ -232,5 +232,530 @@ support: core
             self.assertEqual(pack.domain, "finance")
 
 
+class PackAliasSchemaTest(unittest.TestCase):
+    def _write_pack(self, root: Path, body: str, *, folder: str = "builtin") -> Path:
+        pack_root = root / folder
+        pack_root.mkdir(parents=True)
+        (pack_root / "pack.yaml").write_text(
+            body + ("\n" if not body.endswith("\n") else ""), encoding="utf-8"
+        )
+        return pack_root
+
+    # ------------------------------------------------------------------
+    # Valid alias arrays
+    # ------------------------------------------------------------------
+
+    def test_valid_executor_alias_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.legacy_cut
+    canonical_id: builtin.cut
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(len(pack.aliases), 1)
+            self.assertEqual(pack.aliases[0]["kind"], "executor")
+            self.assertEqual(pack.aliases[0]["alias"], "builtin.legacy_cut")
+            self.assertEqual(pack.aliases[0]["canonical_id"], "builtin.cut")
+            self.assertNotIn("deprecated", pack.aliases[0])
+
+    def test_valid_orchestrator_alias_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: orchestrator
+    alias: builtin.legacy_hype
+    canonical_id: builtin.hype
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(len(pack.aliases), 1)
+            self.assertEqual(pack.aliases[0]["kind"], "orchestrator")
+
+    def test_multiple_aliases_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.a1
+    canonical_id: builtin.real1
+  - kind: executor
+    alias: builtin.a2
+    canonical_id: builtin.real2
+  - kind: orchestrator
+    alias: builtin.a3
+    canonical_id: builtin.real3
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(len(pack.aliases), 3)
+            kinds = [a["kind"] for a in pack.aliases]
+            self.assertEqual(kinds, ["executor", "executor", "orchestrator"])
+
+    def test_aliases_not_present_defaults_to_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(Path(tmp), "id: builtin\n")
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(pack.aliases, ())
+
+    def test_aliases_null_defaults_to_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                "schema_version: 1\nid: builtin\naliases:\n",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(pack.aliases, ())
+
+    def test_aliases_empty_array_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                "schema_version: 1\nid: builtin\naliases: []\n",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(pack.aliases, ())
+
+    def test_alias_with_full_deprecation_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.old
+    canonical_id: builtin.new
+    deprecated: true
+    deprecation_message: "Use builtin.new instead."
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            self.assertEqual(len(pack.aliases), 1)
+            self.assertEqual(pack.aliases[0]["deprecated"], True)
+            self.assertEqual(
+                pack.aliases[0]["deprecation_message"], "Use builtin.new instead."
+            )
+
+    # ------------------------------------------------------------------
+    # Missing/invalid fields
+    # ------------------------------------------------------------------
+
+    def test_aliases_not_array_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                "schema_version: 1\nid: builtin\naliases: not_an_array\n",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be an array"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_aliases_string_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                'schema_version: 1\nid: builtin\naliases: "string"\n',
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be an array"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_entry_not_object_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                "schema_version: 1\nid: builtin\naliases:\n  - just_a_string\n",
+            )
+            with self.assertRaisesRegex(PackValidationError, r"pack\.aliases\[0\] must be an object"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_missing_kind_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - alias: builtin.x
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "missing required field pack.aliases\\[0\\].kind"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_missing_alias_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "missing required field pack.aliases\\[0\\].alias"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_missing_canonical_id_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "missing required field pack.aliases\\[0\\].canonical_id"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_empty_string_alias_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: ""
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be a non-empty"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_empty_string_canonical_id_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: ""
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be a non-empty"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    # ------------------------------------------------------------------
+    # Unknown alias keys
+    # ------------------------------------------------------------------
+
+    def test_alias_unknown_key_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    extra_field: true
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "has unknown field"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_multiple_unknown_keys_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    foo: 1
+    bar: 2
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "bar, foo"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    # ------------------------------------------------------------------
+    # Invalid kind
+    # ------------------------------------------------------------------
+
+    def test_alias_invalid_kind_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: invalid_kind
+    alias: builtin.x
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "kind must be one of"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_kind_element_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: element
+    alias: builtin.x
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "kind must be one of"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_kind_numeric_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: 42
+    alias: builtin.x
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaises(PackValidationError):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    # ------------------------------------------------------------------
+    # Unqualified ids
+    # ------------------------------------------------------------------
+
+    def test_alias_unqualified_alias_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: bare_name
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be qualified as"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_unqualified_canonical_id_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: bare_name
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be qualified as"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_trailing_dot_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be qualified as"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_leading_dot_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: .builtin
+    canonical_id: builtin.y
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "must be qualified as"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    # ------------------------------------------------------------------
+    # Bad deprecation metadata types
+    # ------------------------------------------------------------------
+
+    def test_alias_deprecated_not_bool_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    deprecated: "yes"
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "deprecated must be a boolean"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_deprecated_integer_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    deprecated: 1
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "deprecated must be a boolean"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_deprecation_message_not_string_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    deprecation_message: 123
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "deprecation_message must be a string"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    def test_alias_deprecation_message_boolean_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.x
+    canonical_id: builtin.y
+    deprecation_message: true
+""",
+            )
+            with self.assertRaisesRegex(PackValidationError, "deprecation_message must be a string"):
+                load_pack_manifest(pack_manifest_path(pack_root))
+
+    # ------------------------------------------------------------------
+    # Serialization through PackDefinition.to_dict()
+    # ------------------------------------------------------------------
+
+    def test_aliases_serialize_in_to_dict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.old
+    canonical_id: builtin.new
+    deprecated: true
+    deprecation_message: Migrated
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            payload = pack.to_dict()
+            self.assertIn("aliases", payload)
+            self.assertEqual(len(payload["aliases"]), 1)
+            self.assertEqual(payload["aliases"][0]["kind"], "executor")
+            self.assertEqual(payload["aliases"][0]["alias"], "builtin.old")
+            self.assertEqual(payload["aliases"][0]["canonical_id"], "builtin.new")
+            self.assertEqual(payload["aliases"][0]["deprecated"], True)
+            self.assertEqual(payload["aliases"][0]["deprecation_message"], "Migrated")
+
+    def test_aliases_not_in_to_dict_when_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(Path(tmp), "id: builtin\n")
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            payload = pack.to_dict()
+            self.assertNotIn("aliases", payload)
+
+    def test_aliases_round_trip_through_to_dict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.alpha
+    canonical_id: builtin.beta
+  - kind: orchestrator
+    alias: builtin.gamma
+    canonical_id: builtin.delta
+    deprecated: false
+""",
+            )
+            pack = load_pack_manifest(pack_manifest_path(pack_root))
+            payload = pack.to_dict()
+            self.assertEqual(len(payload["aliases"]), 2)
+            # First alias (no deprecation)
+            self.assertNotIn("deprecated", payload["aliases"][0])
+            # Second alias (deprecated: false is present)
+            self.assertIn("deprecated", payload["aliases"][1])
+            self.assertEqual(payload["aliases"][1]["deprecated"], False)
+
+    def test_aliases_preserved_through_discovery_path(self) -> None:
+        """Verify _pack_definition_for_discovery preserves identical aliases."""
+        with tempfile.TemporaryDirectory() as tmp:
+            from astrid.packs.validate import PackValidator
+
+            pack_root = self._write_pack(
+                Path(tmp),
+                """schema_version: 1
+id: builtin
+aliases:
+  - kind: executor
+    alias: builtin.old
+    canonical_id: builtin.new
+    deprecated: true
+    deprecation_message: Migrated
+""",
+            )
+            pack_direct = load_pack_manifest(pack_manifest_path(pack_root))
+            validator = PackValidator(pack_root)
+            validator._pack_data = validator._load_yaml(pack_root / "pack.yaml")
+            pack_discovery = validator._pack_definition_for_discovery({})
+            self.assertEqual(pack_direct.aliases, pack_discovery.aliases)
+            self.assertEqual(
+                pack_direct.to_dict()["aliases"],
+                pack_discovery.to_dict()["aliases"],
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_packs_validate.py
+++ b/tests/test_packs_validate.py
@@ -756,5 +756,754 @@ runtime:
         )
 
 
+class TestPackLevelAliases(MinimalPackTestCase):
+    """Top-level pack alias validation through validate_pack() and PackValidator."""
+
+    def test_valid_pack_with_aliases_passes_validation(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        self.write_valid_executor(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+
+    def test_pack_alias_unknown_key_fails_validation(self) -> None:
+        """An alias with extra keys fails JSON schema validation
+        because pack.json has additionalProperties: false on alias items."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+    extra_field: true
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("extra_field", "additionalproperties", "unknown field")
+            ),
+            f"Expected schema error about extra field, got: {errors}",
+        )
+
+    def test_pack_alias_unqualified_alias_fails_schema(self) -> None:
+        """An unqualified alias value fails the JSON schema pattern check."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: bare_name
+    canonical_id: test_pack.test_exec
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(term in error_text.lower() for term in ("pattern", "bare_name")),
+            f"Expected schema pattern error for unqualified alias, got: {errors}",
+        )
+
+    def test_pack_alias_invalid_kind_fails_schema(self) -> None:
+        """An invalid kind value fails JSON schema enum check."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: invalid
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            "kind" in error_text.lower()
+            and any(t in error_text.lower() for t in ("enum", "invalid", "not valid")),
+            f"Expected schema enum error for kind, got: {errors}",
+        )
+
+    def test_pack_alias_missing_required_fields_fails_schema(self) -> None:
+        """Missing required alias fields fail JSON schema validation."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(t in error_text.lower() for t in ("required", "alias", "canonical_id")),
+            f"Expected required field error, got: {errors}",
+        )
+
+    def test_pack_alias_not_array_fails_schema(self) -> None:
+        """aliases as string fails JSON schema type check."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases: not_an_array
+""",
+        )
+        errors, warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(t in error_text.lower() for t in ("array", "type", "aliases")),
+            f"Expected type error for aliases, got: {errors}",
+        )
+
+    def test_discovery_preserves_pack_aliases(self) -> None:
+        """_pack_definition_for_discovery preserves aliases from pack data."""
+        root = self.make_pack_root()
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.old_name
+    canonical_id: test_pack.new_name
+    deprecated: true
+    deprecation_message: Moved
+""",
+        )
+        _write(root / "AGENTS.md", "# Test")
+        _write(root / "README.md", "# Test")
+        validator = PackValidator(root)
+        validator._pack_data = validator._load_yaml(root / "pack.yaml")
+        pack = validator._pack_definition_for_discovery({"executors": "executors"})
+        self.assertEqual(len(pack.aliases), 1)
+        self.assertEqual(pack.aliases[0]["kind"], "executor")
+        self.assertEqual(pack.aliases[0]["alias"], "test_pack.old_name")
+        self.assertEqual(pack.aliases[0]["canonical_id"], "test_pack.new_name")
+        self.assertEqual(pack.aliases[0]["deprecated"], True)
+        self.assertEqual(pack.aliases[0]["deprecation_message"], "Moved")
+
+    def test_pack_alias_duplicate_alias_same_kind_fails_validation(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.other_exec
+""",
+        )
+        self.write_valid_executor(root, "executors/other_exec", "test_pack.other_exec")
+        errors, _warnings = validate_pack(root)
+        self.assertTrue(any("duplicates existing executor alias" in error for error in errors), errors)
+
+    def test_pack_alias_duplicate_alias_across_kinds_is_allowed(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        self.write_valid_executor(root)
+        orch_dir = root / "orchestrators" / "test_orch"
+        _write(
+            orch_dir / "orchestrator.yaml",
+            """schema_version: 1
+id: test_pack.test_orch
+name: Test Orchestrator
+version: 0.1.0
+runtime:
+  kind: command
+  command:
+    argv: ["python3", "run.py"]
+""",
+        )
+        _write(orch_dir / "run.py", "print('ok')\n")
+        _write(orch_dir / "STAGE.md", "# Test Orchestrator\n")
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+  - kind: orchestrator
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_orch
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+
+    def test_pack_alias_cycle_fails_validation(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.alias_one
+    canonical_id: test_pack.alias_two
+  - kind: executor
+    alias: test_pack.alias_two
+    canonical_id: test_pack.alias_one
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertTrue(any("alias cycle detected" in error for error in errors), errors)
+
+    def test_pack_alias_missing_local_target_fails_validation(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.missing_exec
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertTrue(any("unknown executor id 'test_pack.missing_exec'" in error for error in errors), errors)
+
+    def test_pack_alias_qualified_cross_pack_target_is_allowed(self) -> None:
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: external.remote_exec
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+
+    # -- non-object shapes inside the aliases array -----------------------
+
+    def test_pack_alias_string_entry_in_array_fails(self) -> None:
+        """A bare string inside the aliases array is not an object."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - just_a_string
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("object", "type", "string", "must be")
+            ),
+            f"Expected error about non-object alias entry, got: {errors}",
+        )
+
+    def test_pack_alias_number_entry_in_array_fails(self) -> None:
+        """A bare number inside the aliases array is not an object."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - 42
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("object", "type", "number", "must be")
+            ),
+            f"Expected error about non-object alias entry, got: {errors}",
+        )
+
+    def test_pack_alias_null_entry_in_array_fails(self) -> None:
+        """A null inside the aliases array is not an object."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - null
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("object", "type", "null", "must be")
+            ),
+            f"Expected error about non-object alias entry, got: {errors}",
+        )
+
+    # -- invalid deprecation metadata ------------------------------------
+
+    def test_pack_alias_deprecated_non_bool_string_fails(self) -> None:
+        """deprecated must be a boolean, not a string."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+    deprecated: "yes"
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("deprecated", "boolean", "string", "type")
+            ),
+            f"Expected error about non-boolean deprecated, got: {errors}",
+        )
+
+    def test_pack_alias_deprecated_non_bool_int_fails(self) -> None:
+        """deprecated must be a boolean, not an integer."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+    deprecated: 1
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("deprecated", "boolean", "integer", "type")
+            ),
+            f"Expected error about non-boolean deprecated, got: {errors}",
+        )
+
+    def test_pack_alias_deprecation_message_non_string_int_fails(self) -> None:
+        """deprecation_message must be a string, not an integer."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+    deprecated: true
+    deprecation_message: 123
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("deprecation_message", "string", "integer", "type")
+            ),
+            f"Expected error about non-string deprecation_message, got: {errors}",
+        )
+
+    def test_pack_alias_deprecation_message_non_string_bool_fails(self) -> None:
+        """deprecation_message must be a string, not a boolean."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases:
+  - kind: executor
+    alias: test_pack.legacy
+    canonical_id: test_pack.test_exec
+    deprecated: true
+    deprecation_message: true
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertGreater(len(errors), 0)
+        error_text = " ".join(errors)
+        self.assertTrue(
+            any(
+                term in error_text.lower()
+                for term in ("deprecation_message", "string", "boolean", "type")
+            ),
+            f"Expected error about non-string deprecation_message, got: {errors}",
+        )
+
+    # -- empty aliases array ---------------------------------------------
+
+    def test_pack_alias_empty_array_passes(self) -> None:
+        """An empty aliases array is valid (no aliases declared)."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        _write(
+            root / "pack.yaml",
+            """schema_version: 1
+id: test_pack
+name: Test Pack
+version: 0.1.0
+description: A test pack.
+content:
+  executors: executors
+  orchestrators: orchestrators
+agent:
+  purpose: Testing
+aliases: []
+""",
+        )
+        errors, _warnings = validate_pack(root)
+        self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+
+
+class TestLegacyComponentMetadataAliases(MinimalPackTestCase):
+    """Legacy component-level metadata.aliases validation (separate from top-level pack aliases)."""
+
+    def test_legacy_alias_targets_must_exist(self) -> None:
+        """Legacy metadata.aliases pointing to unknown capability ids fail."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        comp_dir = root / "executors" / "test_exec"
+        _write(
+            comp_dir / "executor.yaml",
+            """schema_version: 1
+id: test_pack.test_exec
+name: Test Executor
+version: 0.1.0
+runtime:
+  type: python-cli
+  entrypoint: run.py
+metadata:
+  aliases:
+    - canonical_id: test_pack.missing
+""",
+        )
+        _write(comp_dir / "run.py", "# Test executor\n")
+        errors, _ = validate_pack(root)
+        self.assertTrue(
+            any("unknown capability id" in error for error in errors), errors
+        )
+
+    def test_legacy_alias_string_target_must_exist(self) -> None:
+        """Legacy string-form metadata.aliases must resolve to known capability ids."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        comp_dir = root / "executors" / "test_exec"
+        _write(
+            comp_dir / "executor.yaml",
+            """schema_version: 1
+id: test_pack.test_exec
+name: Test Executor
+version: 0.1.0
+runtime:
+  type: python-cli
+  entrypoint: run.py
+metadata:
+  aliases:
+    - test_pack.missing
+""",
+        )
+        _write(comp_dir / "run.py", "# Test executor\n")
+        errors, _ = validate_pack(root)
+        self.assertTrue(
+            any("unknown capability id" in error for error in errors), errors
+        )
+
+    def test_legacy_alias_must_be_string_or_object(self) -> None:
+        """Legacy metadata.aliases entries must be strings or objects, not numbers."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        comp_dir = root / "executors" / "test_exec"
+        _write(
+            comp_dir / "executor.yaml",
+            """schema_version: 1
+id: test_pack.test_exec
+name: Test Executor
+version: 0.1.0
+runtime:
+  type: python-cli
+  entrypoint: run.py
+metadata:
+  aliases:
+    - 42
+""",
+        )
+        _write(comp_dir / "run.py", "# Test executor\n")
+        errors, _ = validate_pack(root)
+        self.assertTrue(
+            any(
+                t in " ".join(errors).lower()
+                for t in ("string or object", "must be")
+            ),
+            f"Expected error about non-string/non-object alias, got: {errors}",
+        )
+
+    def test_legacy_alias_must_declare_canonical_id(self) -> None:
+        """Legacy object-form metadata.aliases must declare canonical_id."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        comp_dir = root / "executors" / "test_exec"
+        _write(
+            comp_dir / "executor.yaml",
+            """schema_version: 1
+id: test_pack.test_exec
+name: Test Executor
+version: 0.1.0
+runtime:
+  type: python-cli
+  entrypoint: run.py
+metadata:
+  aliases:
+    - description: "no canonical_id here"
+""",
+        )
+        _write(comp_dir / "run.py", "# Test executor\n")
+        errors, _ = validate_pack(root)
+        self.assertTrue(
+            any("must declare canonical_id" in error for error in errors), errors
+        )
+
+    def test_legacy_alias_metadata_not_array_fails(self) -> None:
+        """Legacy metadata.aliases must be an array."""
+        root = self.make_pack_root()
+        self.write_valid_pack(root)
+        comp_dir = root / "executors" / "test_exec"
+        _write(
+            comp_dir / "executor.yaml",
+            """schema_version: 1
+id: test_pack.test_exec
+name: Test Executor
+version: 0.1.0
+runtime:
+  type: python-cli
+  entrypoint: run.py
+metadata:
+  aliases: not_an_array
+""",
+        )
+        _write(comp_dir / "run.py", "# Test executor\n")
+        errors, _ = validate_pack(root)
+        self.assertTrue(
+            any("must be an array" in error for error in errors), errors
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_registry_lookup_semantics.py
+++ b/tests/test_registry_lookup_semantics.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from astrid.core.alias_resolver import AliasResolver
+from astrid.contracts.schema import CommandSpec
+from astrid.core.executor import cli as executors_cli
+from astrid.core.executor.install import ExecutorInstallPlan, ExecutorInstallResult
+from astrid.core.executor.registry import ExecutorRegistry
+from astrid.core.executor.schema import ExecutorDefinition
+from astrid.core.orchestrator import cli as orchestrators_cli
+from astrid.core.orchestrator.registry import OrchestratorRegistry
+from astrid.core.orchestrator.schema import OrchestratorDefinition, RuntimeSpec
+from astrid.core.override import OverrideStore
+
+
+def _executor_definition(executor_id: str, *, name: str = "Demo") -> ExecutorDefinition:
+    return ExecutorDefinition(
+        id=executor_id,
+        name=name,
+        kind="built_in",
+        version="1.0.0",
+        metadata={"source": "pack", "source_pack": executor_id.split(".", 1)[0]},
+    )
+
+
+def _orchestrator_definition(orchestrator_id: str, *, name: str = "Demo") -> OrchestratorDefinition:
+    return OrchestratorDefinition(
+        id=orchestrator_id,
+        name=name,
+        kind="built_in",
+        version="1.0.0",
+        runtime=RuntimeSpec(kind="command", command=CommandSpec(argv=("echo", "ok"))),
+        metadata={"source": "pack", "source_pack": orchestrator_id.split(".", 1)[0]},
+    )
+
+
+class RegistryLookupSemanticsTest(unittest.TestCase):
+    def test_executor_registry_get_resolves_alias_and_applies_override_by_canonical_id(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_shots", "builtin.shots")
+        with tempfile.TemporaryDirectory() as tmp:
+            override_store = OverrideStore(project_root=tmp)
+            override_store.set_override("executor", "builtin.shots", "local.shots")
+            registry = ExecutorRegistry(alias_resolver=resolver, override_store=override_store)
+            registry.register(_executor_definition("builtin.shots", name="Shots"))
+            registry.register(_executor_definition("local.shots", name="Local Shots"))
+
+            result = registry.get("builtin.legacy_shots")
+
+        self.assertEqual(result.id, "local.shots")
+        self.assertEqual(result.name, "Local Shots")
+        self.assertNotIn("override_target", result.metadata)
+
+    def test_executor_registry_get_reports_missing_alias_target(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_shots", "builtin.missing")
+        registry = ExecutorRegistry(alias_resolver=resolver)
+
+        with self.assertRaisesRegex(
+            KeyError,
+            r"alias 'builtin\.legacy_shots' points to missing executor 'builtin\.missing'",
+        ):
+            registry.get("builtin.legacy_shots")
+
+    def test_orchestrator_registry_get_resolves_alias_and_applies_override_by_canonical_id(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_hype", "builtin.hype")
+        with tempfile.TemporaryDirectory() as tmp:
+            override_store = OverrideStore(project_root=tmp)
+            override_store.set_override("orchestrator", "builtin.hype", "local.hype")
+            registry = OrchestratorRegistry(alias_resolver=resolver, override_store=override_store)
+            registry.register(_orchestrator_definition("builtin.hype", name="Hype"))
+            registry.register(_orchestrator_definition("local.hype", name="Local Hype"))
+
+            result = registry.get("builtin.legacy_hype")
+
+        self.assertEqual(result.id, "local.hype")
+        self.assertEqual(result.name, "Local Hype")
+        self.assertNotIn("override_target", result.metadata)
+
+    def test_orchestrator_registry_get_reports_missing_alias_target(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_hype", "builtin.missing")
+        registry = OrchestratorRegistry(alias_resolver=resolver)
+
+        with self.assertRaisesRegex(
+            KeyError,
+            r"alias 'builtin\.legacy_hype' points to missing orchestrator 'builtin\.missing'",
+        ):
+            registry.get("builtin.legacy_hype")
+
+    def test_executor_cli_paths_use_registry_lookup_for_aliases(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_demo", "builtin.demo")
+        registry = ExecutorRegistry(alias_resolver=resolver)
+        registry.register(_executor_definition("builtin.demo"))
+
+        inspect_stdout = io.StringIO()
+        with contextlib.redirect_stdout(inspect_stdout):
+            rc = executors_cli._cmd_inspect(
+                argparse.Namespace(
+                    executor_id="builtin.legacy_demo",
+                    json=True,
+                    pack=None,
+                    show_overrides=False,
+                ),
+                registry,
+            )
+        self.assertEqual(rc, 0)
+        inspect_payload = json.loads(inspect_stdout.getvalue())
+        self.assertEqual(inspect_payload["id"], "builtin.demo")
+        self.assertEqual(
+            inspect_payload["_capability"]["aliases"][0]["alias"],
+            "builtin.legacy_demo",
+        )
+
+        validate_stdout = io.StringIO()
+        with contextlib.redirect_stdout(validate_stdout):
+            rc = executors_cli._cmd_validate(
+                argparse.Namespace(
+                    executor_id="builtin.legacy_demo",
+                    check_binaries=False,
+                ),
+                registry,
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("builtin.legacy_demo: ok", validate_stdout.getvalue())
+
+        install_result = ExecutorInstallResult(
+            plan=ExecutorInstallPlan(
+                executor_id="builtin.demo",
+                kind="built_in",
+                environment_path=None,
+                python_path=None,
+                noop_reason="built-in executors use the host Python environment",
+            ),
+            dry_run=True,
+            returncode=0,
+        )
+        with patch("astrid.core.executor.install.install_executor", return_value=install_result) as install_mock:
+            install_stdout = io.StringIO()
+            with contextlib.redirect_stdout(install_stdout):
+                rc = executors_cli._cmd_install(
+                    argparse.Namespace(
+                        executor_id="builtin.legacy_demo",
+                        dry_run=True,
+                    ),
+                    registry,
+                )
+        self.assertEqual(rc, 0)
+        installed_executor = install_mock.call_args.args[0]
+        self.assertEqual(installed_executor.id, "builtin.demo")
+        self.assertIn("builtin.demo: no install needed", install_stdout.getvalue())
+
+    def test_orchestrator_cli_paths_use_registry_lookup_for_aliases(self) -> None:
+        resolver = AliasResolver()
+        resolver.register_alias("builtin.legacy_demo", "builtin.demo")
+        registry = OrchestratorRegistry(
+            alias_resolver=resolver,
+            executor_registry=ExecutorRegistry(),
+        )
+        registry.register(_orchestrator_definition("builtin.demo"))
+
+        inspect_stdout = io.StringIO()
+        with contextlib.redirect_stdout(inspect_stdout):
+            rc = orchestrators_cli._cmd_inspect(
+                argparse.Namespace(
+                    orchestrator_id="builtin.legacy_demo",
+                    json=True,
+                    pack=None,
+                    show_overrides=False,
+                ),
+                registry,
+            )
+        self.assertEqual(rc, 0)
+        inspect_payload = json.loads(inspect_stdout.getvalue())
+        self.assertEqual(inspect_payload["id"], "builtin.demo")
+        self.assertEqual(
+            inspect_payload["_capability"]["aliases"][0]["alias"],
+            "builtin.legacy_demo",
+        )
+
+        validate_stdout = io.StringIO()
+        with contextlib.redirect_stdout(validate_stdout):
+            rc = orchestrators_cli._cmd_validate(
+                argparse.Namespace(orchestrator_id="builtin.legacy_demo"),
+                registry,
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("builtin.legacy_demo: ok", validate_stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Automated megaplan chain milestone `m2-alias-compatibility`.

Idea file: `docs/megaplan/epics/pack-taxonomy/briefs/m2-alias-compatibility.md`
