### PR TITLE
packs: agent-search metadata + repair agent-index/inspect + ranked search

### DIFF
--- a/astrid/packs/builtin/pack.yaml
+++ b/astrid/packs/builtin/pack.yaml
@@ -10,3 +10,10 @@ domain: system
 stability: stable
 support: core
 permissions: []
+description: Deprecated core namespace; its executors and orchestrators have been split into the editorial, foley, and generation packs.
+keywords: [builtin, core, deprecated, legacy, namespace, aliases]
+capabilities: []
+agent:
+  purpose: "Historical core namespace retained only for backward-compatible aliases (builtin.*). It ships no live components of its own."
+  do_not_use_for: "Anything real — pick the pack that now owns the capability (editorial for cut/transcript work, foley for spatial audio, generation for image/video synthesis, fal for fal.ai)."
+  normal_entrypoints: []

--- a/astrid/packs/cli.py
+++ b/astrid/packs/cli.py
@@ -314,6 +314,7 @@ def _create_pack_skeleton(pack_id: str) -> int:
 id: {pack_id}
 name: {pack_name}
 version: 0.1.0
+# One-line summary shown in `packs list` and search results. Make it specific.
 description: {description}
 origin: external
 install_tier: core
@@ -321,12 +322,18 @@ pack_type: capability
 domain: system
 stability: stable
 support: core
+# Search/selection metadata: agents find and choose packs by these. Fill them in.
+keywords: []          # search terms an agent would type, e.g. [video, editing, ffmpeg]
+capabilities: []      # concrete things this pack can do, e.g. [trim_clip, concat, add_subtitles]
 content:
   executors: executors
   orchestrators: orchestrators
   elements: elements
 agent:
   purpose: "TODO: describe what this pack is for"
+  do_not_use_for: "TODO: when an agent should NOT pick this pack"
+  normal_entrypoints: []   # orchestrator/executor ids an agent should start with
+  required_context: []     # inputs/secrets an agent must have before using this pack
 """,
         encoding="utf-8",
     )

--- a/astrid/packs/cli.py
+++ b/astrid/packs/cli.py
@@ -26,7 +26,7 @@ from astrid.core.pack import (
     packs_root,
 )
 from astrid.core.element.schema import ELEMENT_MANIFEST_NAMES
-from astrid.packs.validate import validate_pack
+from astrid.packs.validate import extract_trust_summary, validate_pack
 
 # Must match the pack_id pattern in _defs.json: lowercase, digits, underscore
 _PACK_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -1388,6 +1388,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     agent_index_parser.set_defaults(handler=_handle_agent_index)
 
+    # ── search ──
+    search_parser = subparsers.add_parser(
+        "search",
+        help="Search packs by keyword/capability/purpose (ranked).",
+    )
+    search_parser.add_argument(
+        "query",
+        nargs="+",
+        help="One or more search terms (matched against id, name, "
+        "description, keywords, capabilities, and purpose).",
+    )
+    search_parser.add_argument(
+        "--limit", type=int, default=20,
+        help="Maximum results to show (default: 20; <=0 for all).",
+    )
+    search_parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON.",
+    )
+    search_parser.set_defaults(handler=_handle_search)
+
     return parser
 
 
@@ -1497,14 +1517,13 @@ def _handle_rollback(args: argparse.Namespace) -> int:
 def _handle_agent_index(args: argparse.Namespace) -> int:
     """Handler for ``packs agent-index``."""
 
-    from astrid.core.pack import PackResolver, packs_root
     from astrid.core.pack_store import InstalledPackStore
+    from astrid.packs.agent_index import build_agent_index
 
-    resolver = PackResolver(packs_root())
     store = InstalledPackStore()
 
     pack_id = getattr(args, "pack_id", None)
-    result = build_agent_index(resolver, store, pack_id=pack_id)
+    result = build_agent_index(store, pack_id=pack_id)
 
     if args.text_output:
         # Text table output
@@ -1593,6 +1612,108 @@ def _handle_agent_index(args: argparse.Namespace) -> int:
 
     return 0
 
+
+# ---------------------------------------------------------------------------
+# pack search
+# ---------------------------------------------------------------------------
+
+# Per-field weights for ranking a query term against a pack. Keyword and
+# capability hits are the strongest signal (authored for discovery); id/name
+# next; purpose/description are softer free-text matches. do_not_use_for is
+# deliberately excluded so negative guidance never yields a positive match.
+_SEARCH_FIELD_WEIGHTS = (
+    ("keywords", 3.0),
+    ("capabilities", 3.0),
+    ("pack_id", 2.0),
+    ("name", 2.0),
+    ("purpose", 1.5),
+    ("description", 1.0),
+)
+
+
+def _pack_search_text(pack: dict[str, Any], field: str) -> str:
+    """Return lowercased searchable text for *field* of an agent-index entry."""
+    value = pack.get(field)
+    if isinstance(value, (list, tuple)):
+        return " ".join(str(v) for v in value).lower()
+    return str(value or "").lower()
+
+
+def _score_pack(pack: dict[str, Any], terms: list[str]) -> float:
+    """Score *pack* against query *terms*; 0.0 means no match.
+
+    Every term must hit at least one field (AND semantics); a single
+    unmatched term drops the pack, keeping multi-word queries precise
+    rather than returning anything that matches one common word.
+    """
+    total = 0.0
+    for term in terms:
+        best = 0.0
+        for field, weight in _SEARCH_FIELD_WEIGHTS:
+            if term in _pack_search_text(pack, field):
+                best = max(best, weight)
+        if best == 0.0:
+            return 0.0
+        total += best
+    return total
+
+
+def _handle_search(args: argparse.Namespace) -> int:
+    """Handler for ``packs search``."""
+    from astrid.core.pack_store import InstalledPackStore
+    from astrid.packs.agent_index import build_agent_index
+
+    terms = [t.lower() for t in args.query if t.strip()]
+    if not terms:
+        print("search: empty query", file=sys.stderr)
+        return 2
+
+    index = build_agent_index(InstalledPackStore())
+    packs = index.get("packs", []) if isinstance(index, dict) else []
+
+    scored = [
+        (score, pack)
+        for pack in packs
+        if (score := _score_pack(pack, terms)) > 0.0
+    ]
+    scored.sort(key=lambda sp: (-sp[0], str(sp[1].get("pack_id", ""))))
+
+    total = len(scored)
+    limit = args.limit if args.limit and args.limit > 0 else total
+    shown = scored[:limit]
+
+    if args.json:
+        payload = {
+            "query": terms,
+            "total": total,
+            "shown": len(shown),
+            "packs": [
+                {**pack, "search_score": round(score, 2)}
+                for score, pack in shown
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if not shown:
+        print(f"No packs match: {' '.join(terms)}")
+        return 0
+
+    for score, pack in shown:
+        summary = pack.get("purpose") or pack.get("description") or ""
+        keywords = pack.get("keywords") or []
+        kw = ", ".join(str(k) for k in keywords[:6])
+        line = f"{pack.get('pack_id', '?')}\t{score:g}\t{summary}"
+        if kw:
+            line += f"\t[{kw}]"
+        print(line)
+
+    if total > len(shown):
+        print(
+            f"\n# showing top {len(shown)} of {total} matches — "
+            f"add terms to narrow, or pass --limit to see more"
+        )
+    return 0
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/astrid/packs/editorial/pack.yaml
+++ b/astrid/packs/editorial/pack.yaml
@@ -14,7 +14,13 @@ permissions:
     reason: Runs editorial executors as subprocesses for transcription, review, and arrangement.
   - id: project_files
     reason: Reads and writes transcripts, scenes, arrangements, and review artifacts.
-description: Editorial review, arrangement, and validation executors.
+description: Transcript-to-cut editorial pipeline — transcribe, detect scenes/shots, arrange clip pools, run heuristic and human review, and validate the rendered cut.
+keywords: [transcribe, scenes, shots, arrange, review, validate, transcript, editorial]
+capabilities: [transcribe_audio, detect_scenes, slice_shots, arrange_clips, refine_arrangement, grade_quality_zones, run_editor_review, collect_human_review, ingest_human_notes, scout_quotes, generate_script, inspect_cut, validate_cut]
+agent:
+  purpose: "Use for the narrative-editing workflow: turning source video/audio into a structured cut — transcription, scene/shot detection, clip-pool arrangement, reviewer notes (heuristic or human-in-the-loop), and final cut validation."
+  do_not_use_for: "Generating new image/video frames (use the generation pack), Foley/spatial audio (use the foley pack), or raw lossless trimming (use the media pack)."
+  normal_entrypoints: [editorial.transcribe, editorial.scenes, editorial.shots, editorial.arrange, editorial.validate]
 content:
   executors: executors
 aliases:

--- a/astrid/packs/fal/pack.yaml
+++ b/astrid/packs/fal/pack.yaml
@@ -18,7 +18,13 @@ permissions:
     reason: Reads input video clips and writes generated audio files.
   - id: environment
     reason: Reads FAL_KEY for fal.ai API authentication.
-description: fal.ai integration executors.
+description: fal.ai integration — generates Foley audio for short video clips via fal.ai's hunyuan-video-foley model.
+keywords: [fal, foley, audio, hunyuan, video, api, integration]
+capabilities: [generate_clip_foley]
+agent:
+  purpose: "Use to call fal.ai's hunyuan-video-foley model to synthesize a Foley audio track for a single short video clip (requires FAL_KEY)."
+  do_not_use_for: "Orchestrating a full spatial-Foley pass over a whole video (use the foley pack's foley_map, which calls this executor per tile) or image/video frame generation (use the generation pack)."
+  normal_entrypoints: [fal.fal_foley]
 content:
   executors: executors
 aliases:

--- a/astrid/packs/foley/pack.yaml
+++ b/astrid/packs/foley/pack.yaml
@@ -14,7 +14,13 @@ permissions:
     reason: Runs ffmpeg for audio and video foley processing.
   - id: project_files
     reason: Reads source media files and writes foley-processed outputs.
-description: Foley processing executors and orchestration.
+description: Spatial Foley pipeline — tile a video, prompt a VLM for per-tile audio cues, score Foley per tile, and emit a position-mixed viewer.
+keywords: [foley, audio, spatial, tile, video, viewer, vlm, soundscape]
+capabilities: [tile_video, review_foley, build_spatial_viewer, orchestrate_spatial_foley]
+agent:
+  purpose: "Use to build a spatial soundscape for a video: it tiles the frame, asks a VLM for per-tile prompts, generates Foley per tile (via fal.fal_foley), and renders a viewer that mixes tracks by viewport position."
+  do_not_use_for: "Generating Foley for a single whole clip (call fal.fal_foley directly) or transcript/cut editorial work (use the editorial pack)."
+  normal_entrypoints: [foley.foley_map]
 content:
   executors: executors
   orchestrators: orchestrators

--- a/astrid/packs/generation/pack.yaml
+++ b/astrid/packs/generation/pack.yaml
@@ -18,7 +18,13 @@ permissions:
     reason: Reads reference images and prompt files; writes generated outputs.
   - id: environment
     reason: Reads FAL_KEY for cloud generation backends.
-description: Generative image and video executors.
+description: Text-to-image and text-to-video generation across local (vibecomfy/ComfyUI) and cloud (fal, OpenAI) backends, with t2i/i2i/edit and t2v/i2v/flf modes.
+keywords: [image, video, generate, flux, fal, vibecomfy, t2i, t2v]
+capabilities: [generate_image, generate_image_openai, generate_video]
+agent:
+  purpose: "Use to synthesize new image or video frames from text prompts (optionally with reference images), choosing a model and a local or cloud execution backend."
+  do_not_use_for: "Editing/arranging existing footage (use the editorial pack), Foley/audio generation (use the foley or fal packs), or lossless clip trimming (use the media pack)."
+  normal_entrypoints: [generation.generate_image, generation.generate_video, generation.generate_image_openai]
 content:
   executors: executors
 aliases:

--- a/astrid/packs/iteration/pack.yaml
+++ b/astrid/packs/iteration/pack.yaml
@@ -13,6 +13,28 @@ permissions:
     reason: Runs iteration assembly and preparation executors as subprocesses.
   - id: project_files
     reason: Reads iteration manifests and writes timeline and asset files.
+description: Builds an iteration video from thread provenance — gathers candidate runs, scores quality, and assembles a canonical iteration timeline plus render-ready hype inputs.
+keywords:
+  - iteration
+  - provenance
+  - thread
+  - quality
+  - timeline
+  - hype
+  - video
+  - assemble
+capabilities:
+  - prepare_iteration
+  - collect_thread_provenance
+  - score_iteration_quality
+  - assemble_iteration_timeline
+  - emit_render_adapter
 content:
   executors: executors
   orchestrators: orchestrators
+agent:
+  purpose: "Use to turn a thread's run history into an iteration video artifact: prepare provenance/quality from a target run, then assemble the canonical iteration timeline and render-compatible hype inputs."
+  do_not_use_for: "Not for raw video editing or clip trimming (use the media pack) or final video rendering (use the rendering pack on the emitted hype adapter)."
+  normal_entrypoints:
+    - iteration.prepare
+    - iteration.assemble

--- a/astrid/packs/media/pack.yaml
+++ b/astrid/packs/media/pack.yaml
@@ -14,9 +14,23 @@ permissions:
   - id: project_files
     reason: Reads source video files and writes output clips.
 description: Media processing tools, currently providing lossless video clip extraction via ffmpeg stream copy.
+keywords:
+  - video
+  - clip
+  - ffmpeg
+  - extract
+  - trim
+  - segment
+  - lossless
+capabilities:
+  - extract_clip
+  - trim_video
 content:
   executors: executors
   orchestrators: orchestrators
   elements: elements
 agent:
   purpose: "Use when you need to trim a segment from a video file quickly and losslessly (ffmpeg -ss/-t/-c copy)."
+  do_not_use_for: "Not for building iteration videos from run history (use the iteration pack) or final timeline rendering (use the rendering pack)."
+  normal_entrypoints:
+    - media.clip_extract

--- a/astrid/packs/moirae/pack.yaml
+++ b/astrid/packs/moirae/pack.yaml
@@ -14,9 +14,26 @@ permissions:
     reason: Runs Moirae terminal-as-cinema renderer with asciinema and ffmpeg.
   - id: project_files
     reason: Reads screenplay files and writes rendered video.
-description: Moirae integration executors.
+description: Renders a YAML screenplay into a terminal-as-cinema video via Moirae (asciinema, agg, ffmpeg).
+keywords:
+  - moirae
+  - terminal
+  - screenplay
+  - asciinema
+  - render
+  - video
+  - demo
+  - cinema
+capabilities:
+  - render_screenplay
+  - produce_terminal_video
 content:
   executors: executors
+agent:
+  purpose: "Use to turn a Moirae screenplay file into a scripted terminal/CLI demo video (typewriter text, simulated agent Q&A, camera moves). External pack — requires the moirae package plus asciinema, agg, and ffmpeg binaries."
+  do_not_use_for: "Not for trimming real video files (use the media pack) or assembling iteration videos from run provenance (use the iteration pack)."
+  normal_entrypoints:
+    - moirae.moirae
 aliases:
 - kind: executor
   alias: external.moirae

--- a/astrid/packs/reigh/pack.yaml
+++ b/astrid/packs/reigh/pack.yaml
@@ -18,7 +18,27 @@ permissions:
     reason: Publishes timelines and assets to Reigh API.
   - id: environment
     reason: Reads REIGH_USER_TOKEN and REIGH_SUPABASE_URL.
-description: Reigh platform integration executors.
+description: Reigh platform integration — publish timelines/assets into Reigh projects, fetch project data, and build spatial-audio handoff pages.
+keywords:
+- reigh
+- publish
+- timeline
+- assets
+- project
+- handoff
+- spatial-audio
+- edge-function
+capabilities:
+- publish_timeline
+- open_in_reigh
+- fetch_reigh_data
+- build_spatial_audio_page
+agent:
+  purpose: Choose this pack when you need to hand off Astrid-generated timelines and assets to the Reigh platform — publishing them into a Reigh project, fetching canonical project data, or building a spatial-audio preview page.
+  do_not_use_for: Not for rendering or producing the timeline/video itself; use the rendering pack to generate output before publishing here.
+  normal_entrypoints:
+  - reigh.publish
+  - reigh.reigh_data
 content:
   executors: executors
 aliases:

--- a/astrid/packs/rendering/pack.yaml
+++ b/astrid/packs/rendering/pack.yaml
@@ -16,7 +16,26 @@ permissions:
     reason: Reads timeline, asset, and theme files; writes rendered video.
   - id: network
     reason: Sprite sheet executor calls OpenAI GPT Image API.
-description: Rendering executors and render-time visual elements.
+description: Render timelines to video via Remotion, generate GPT-Image sprite sheets, and supply render-time animation/transition/effect elements.
+keywords:
+- render
+- remotion
+- video
+- mp4
+- timeline
+- sprite-sheet
+- gpt-image
+- animation
+capabilities:
+- render_timeline
+- generate_sprite_sheet
+- create_canvas_effect
+agent:
+  purpose: Choose this pack to turn a brief timeline into a finished video (hype.mp4) via Remotion, to generate/slice GPT Image sprite sheets, or to wrap content in a canvas/WebGL post-processing effect.
+  do_not_use_for: Not for publishing the rendered output to the Reigh platform; use the reigh pack for handoff after rendering.
+  normal_entrypoints:
+  - rendering.render
+  - rendering.sprite_sheet
 content:
   executors: executors
   elements: elements

--- a/astrid/packs/runpod/pack.yaml
+++ b/astrid/packs/runpod/pack.yaml
@@ -18,7 +18,28 @@ permissions:
     reason: Reads RUNPOD_API_KEY for authentication.
   - id: external_services
     reason: Manages cloud GPU infrastructure on RunPod.
-description: RunPod provisioning and remote execution executors.
+description: Provision RunPod GPU pods, ship and run scripts on them, pull artifacts, and tear pods down — including a guaranteed-cleanup composite session.
+keywords:
+- runpod
+- gpu
+- provision
+- exec
+- pull
+- teardown
+- session
+- ssh
+capabilities:
+- provision_pod
+- exec_on_pod
+- pull_artifacts
+- teardown_pod
+- run_pod_session
+agent:
+  purpose: Choose this pack when you need ephemeral cloud GPU compute on RunPod — to spin up a pod, run a script remotely, retrieve artifacts/checkpoints, and shut it down. Prefer runpod.session for one-shot jobs that should always clean up.
+  do_not_use_for: Not for orchestrating LoRA training workflows end to end; use the training pack, which drives RunPod under the hood.
+  normal_entrypoints:
+  - runpod.session
+  - runpod.provision
 content:
   executors: executors
 aliases:

--- a/astrid/packs/training/pack.yaml
+++ b/astrid/packs/training/pack.yaml
@@ -18,7 +18,29 @@ permissions:
     reason: Training run orchestrator provisions RunPod GPUs and downloads checkpoints.
   - id: environment
     reason: Reads RunPod API credentials for GPU provisioning.
-description: Dataset and training executors plus training orchestrators.
+description: Build video training datasets and run LoRA training end to end — clip pools, captioning/review, RunPod-backed trainer execution, and checkpoint registration.
+keywords:
+- training
+- lora
+- dataset
+- captioning
+- runpod
+- checkpoint
+- pool
+- huggingface
+capabilities:
+- build_dataset
+- run_training
+- build_clip_pool
+- merge_clip_pool
+- search_loras
+- manage_asset_cache
+agent:
+  purpose: Choose this pack to assemble a video training dataset (acquire, split, caption, review) or to run a LoRA training job that provisions GPUs, executes the trainer remotely, pulls checkpoints, and registers artifacts.
+  do_not_use_for: Not for raw GPU provisioning or one-off remote script execution on its own; use the runpod pack for bare pod lifecycle control.
+  normal_entrypoints:
+  - training.training_run
+  - training.dataset_build
 content:
   executors: executors
   orchestrators: orchestrators

--- a/astrid/packs/understanding/pack.yaml
+++ b/astrid/packs/understanding/pack.yaml
@@ -14,7 +14,28 @@ permissions:
     reason: Runs audio, visual, and video understanding executors.
   - id: project_files
     reason: Reads audio, video, and image files for analysis.
-description: Audio, visual, and video understanding executors.
+description: LLM-based audio, image, and video understanding — caption, query, and structured extraction over media.
+keywords:
+- understanding
+- caption
+- vision
+- audio
+- video
+- transcribe-scene
+- llm
+- structured-output
+capabilities:
+- understand_media
+- understand_audio
+- understand_image
+- understand_video
+- describe_scene
+agent:
+  purpose: Choose this pack to inspect or describe media content — caption images/scenes, query audio or synchronized audio+video windows, or extract schema-constrained structured fields from a clip via an LLM.
+  do_not_use_for: Do not use to edit, cut, or render video (use video_editing) or to generate new media (use vibecomfy).
+  normal_entrypoints:
+  - understanding.understand
+  - understanding.scene_describe
 content:
   executors: executors
 aliases:

--- a/astrid/packs/vibecomfy/pack.yaml
+++ b/astrid/packs/vibecomfy/pack.yaml
@@ -18,7 +18,25 @@ permissions:
     reason: Reads workflow JSON files and writes generated outputs.
   - id: accelerator
     reason: May use GPU for ComfyUI model inference.
-description: VibeComfy and ComfyUI workflow executors.
+description: Run and validate ComfyUI / VibeComfy workflow JSON to generate images, video, and audio.
+keywords:
+- comfyui
+- vibecomfy
+- workflow
+- generate
+- image
+- video
+- gpu
+- runpod
+capabilities:
+- run_workflow
+- validate_workflow
+agent:
+  purpose: Choose this pack to execute or validate a ComfyUI/VibeComfy workflow JSON — generating images, video, or audio from a graph, locally or on GPU.
+  do_not_use_for: Do not use to understand existing media (use understanding) or to cut/render timelines (use video_editing); it runs workflow graphs, not editorial pipelines.
+  normal_entrypoints:
+  - vibecomfy.run
+  - vibecomfy.validate
 content:
   executors: executors
 aliases:

--- a/astrid/packs/video_editing/pack.yaml
+++ b/astrid/packs/video_editing/pack.yaml
@@ -14,7 +14,32 @@ permissions:
     reason: Runs ffmpeg-based cut and foley executors plus orchestrator child processes.
   - id: project_files
     reason: Reads and writes timelines, assets, and editorial artifacts.
-description: Timeline editing executors and video production orchestrators.
+description: End-to-end video production orchestrators (hype edits, talks, thumbnails, logos, image animation) plus the timeline-cut executor.
+keywords:
+- video
+- timeline
+- edit
+- hype
+- thumbnail
+- render
+- animate
+- grid
+capabilities:
+- run_hype_pipeline
+- build_timeline
+- assemble_event_talk
+- make_thumbnails
+- generate_logo_grid
+- animate_image
+- vary_image_grid
+- render_iteration_video
+agent:
+  purpose: Choose this pack to assemble and render finished video from source media — run the canonical hype edit pipeline, build event-talk videos, or generate thumbnails, logo grids, and animated/varied images.
+  do_not_use_for: Do not use to merely understand/caption media (use understanding) or to run a raw ComfyUI generation graph (use vibecomfy); this pack owns the editorial assembly and render flow, distinct from the editorial pack's analysis stages it depends on.
+  normal_entrypoints:
+  - video_editing.hype
+  - video_editing.event_talks
+  - video_editing.thumbnail_maker
 content:
   executors: executors
   orchestrators: orchestrators

--- a/astrid/packs/youtube/pack.yaml
+++ b/astrid/packs/youtube/pack.yaml
@@ -18,7 +18,26 @@ permissions:
     reason: Reads video files for upload and writes downloaded audio.
   - id: environment
     reason: Reads YouTube and social API credentials.
-description: YouTube source acquisition and publishing executors.
+description: Acquire YouTube media (audio MP3 / video MP4 via yt-dlp) and publish finished videos to YouTube.
+keywords:
+- youtube
+- yt-dlp
+- download
+- audio
+- upload
+- publish
+- mp3
+- zapier
+capabilities:
+- download_youtube_audio
+- download_youtube_video
+- upload_youtube_video
+agent:
+  purpose: Choose this pack to fetch a YouTube video's audio or video (by search query or URL) for downstream use, or to publish a finished video to YouTube.
+  do_not_use_for: Do not use to edit or render the video itself (use video_editing) or to analyze its content (use understanding); this pack only ingests and publishes.
+  normal_entrypoints:
+  - youtube.youtube_audio
+  - youtube.upload
 content:
   executors: executors
 aliases:

--- a/docs/templates/executor/executor.yaml
+++ b/docs/templates/executor/executor.yaml
@@ -25,7 +25,7 @@
     "argv": [
       "{python_exec}",
       "-m",
-      "astrid.packs.rendering.example.run",
+      "astrid.packs.builtin.example.run",
       "--input",
       "{input}",
       "--out",
@@ -40,7 +40,7 @@
     "network": false
   },
   "metadata": {
-    "runtime_module": "astrid.packs.rendering.example.run",
+    "runtime_module": "astrid.packs.builtin.example.run",
     "runtime_file": "run.py"
   }
 }

--- a/docs/templates/orchestrator/orchestrator.yaml
+++ b/docs/templates/orchestrator/orchestrator.yaml
@@ -13,20 +13,20 @@
       "argv": [
         "{python_exec}",
         "-m",
-        "astrid.packs.rendering.example.run",
+        "astrid.packs.builtin.example.run",
         "{orchestrator_args}"
       ]
     }
   },
   "child_executors": [
-    "rendering.example_executor"
+    "builtin.example_executor"
   ],
   "child_orchestrators": [],
   "cache": {
     "mode": "none"
   },
   "metadata": {
-    "runtime_module": "astrid.packs.rendering.example.run",
+    "runtime_module": "astrid.packs.builtin.example.run",
     "runtime_file": "run.py"
   }
 }

--- a/tests/test_packs_cli.py
+++ b/tests/test_packs_cli.py
@@ -1161,5 +1161,95 @@ class TestAgentIndexPermissionsAndTrust(unittest.TestCase):
         self.assertEqual(entry["trust"]["sandbox"], "none")
 
 
+class TestAgentIndexAndInspectWiring(unittest.TestCase):
+    """Regression: agent-index and the installed-pack inspect path referenced
+    names that were never imported (PackResolver / extract_trust_summary) and
+    blew up on invocation. No CLI-level test exercised them."""
+
+    def test_agent_index_cli_runs_and_exposes_search_metadata(self) -> None:
+        # Previously: ImportError (PackResolver) before producing any output.
+        result = _run_packs("agent-index", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertIn("packs", data)
+        ids = {p["pack_id"] for p in data["packs"]}
+        self.assertIn("training", ids)
+        training = next(p for p in data["packs"] if p["pack_id"] == "training")
+        self.assertTrue(training.get("keywords"), "agent-index must expose keywords")
+        self.assertTrue(training.get("capabilities"), "agent-index must expose capabilities")
+
+    def test_agent_index_single_pack_form(self) -> None:
+        result = _run_packs("agent-index", "--pack-id", "training", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data.get("pack_id"), "training")
+
+    def test_extract_trust_summary_bound_in_cli_module(self) -> None:
+        # The installed-inspect path calls extract_trust_summary; it must be
+        # importable from the cli module (was previously unbound -> NameError).
+        self.assertTrue(callable(packs_cli.extract_trust_summary))
+
+    def test_inspect_installed_path_executes_without_nameerror(self) -> None:
+        gen_root = _REPO_ROOT / "astrid" / "packs" / "generation"
+        record = InstallRecord(
+            pack_id="generation", name="Astrid Generation", version="1.0.0",
+            schema_version=1, source_path=str(gen_root),
+            installed_at="2025-01-01T00:00:00Z", revision="generation",
+            install_root=str(gen_root),
+        )
+        with mock.patch(
+            "astrid.core.pack_store.InstalledPackStore.get_active",
+            return_value=record,
+        ), mock.patch(
+            "astrid.core.pack_store.InstalledPackStore.active_revision_path",
+            return_value=gen_root,
+        ):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = packs_cli._inspect_installed_pack(
+                    pack_id="generation", agent=False, json_output=True,
+                )
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["pack_id"], "generation")
+
+
+class TestPacksSearchCLI(unittest.TestCase):
+    """packs search ranks packs by keyword/capability/purpose over the agent index."""
+
+    def test_search_finds_pack_by_keyword(self) -> None:
+        result = _run_packs("search", "lora", "--json", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ids = {p["pack_id"] for p in json.loads(result.stdout)["packs"]}
+        self.assertIn("training", ids)
+
+    def test_search_results_are_sorted_by_descending_score(self) -> None:
+        result = _run_packs("search", "video", "--json", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        scores = [p["search_score"] for p in json.loads(result.stdout)["packs"]]
+        self.assertGreater(len(scores), 1)
+        self.assertEqual(scores, sorted(scores, reverse=True))
+        self.assertTrue(all(s > 0 for s in scores))
+
+    def test_search_no_match_is_empty_not_error(self) -> None:
+        result = _run_packs("search", "zzqqnomatchxyz", "--json", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["total"], 0)
+        self.assertEqual(data["packs"], [])
+
+    def test_search_limit_discloses_truncation(self) -> None:
+        # 'video' matches several packs; --limit 1 must disclose the rest exist.
+        result = _run_packs("search", "video", "--limit", "1", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("showing top 1 of", result.stdout)
+
+    def test_search_multiword_requires_all_terms(self) -> None:
+        result = _run_packs("search", "youtube", "download", "--json", cwd=str(_REPO_ROOT))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ids = {p["pack_id"] for p in json.loads(result.stdout)["packs"]}
+        self.assertIn("youtube", ids)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Makes installed packs actually discoverable by an agent: gives every pack real search metadata, repairs the (dead-on-main) agent-facing CLI, and adds a ranked `packs search`.

### 1. Backfill agent-search metadata (16 built-in packs)
Filled `description` / `keywords` / `capabilities` + `agent.purpose` / `do_not_use_for` / `normal_entrypoints` across all built-in packs. Before this, `agent.purpose` was set on 1/17 packs and `keywords`/`capabilities` on 0/17 — so search/ranking had nothing to rank on. The schema already recognized these fields; they were just never populated.

### 2. Prompt the metadata in the scaffold
`packs new` now emits those fields as a self-documenting checklist (with inline examples), so new packs ship discovery metadata by default instead of starting blind.

### 3. Repair the agent-facing CLI (pre-existing bugs on main)
- **`packs agent-index`** — imported a non-existent `PackResolver` and called `build_agent_index()` with the wrong signature (and never imported it) → `ImportError` before producing output. Now calls `build_agent_index(store, pack_id=...)`.
- **`packs inspect <installed-pack>`** — used `extract_trust_summary` without importing it → `NameError` on the installed path.

Neither had any CLI-level test, which is why the wiring rot went unnoticed.

### 4. New: `packs search <terms>`
Ranks discovered + installed packs over `keywords` / `capabilities` / `id` / `name` / `purpose` / `description` (built on `build_agent_index`). AND-semantics across terms; honest `# showing top N of M` overflow footer — no pagination, no silent truncation.

### 5. Fix dangling scaffold-template module refs
`docs/templates/{executor,orchestrator}` declared `builtin.*` ids but pointed `command.argv`/`runtime_module` at `astrid.packs.rendering.example.run` (never existed), failing `test_docs_scaffold_templates_validate_in_minimal_pack` on main. Aligned to `builtin.example`.

## Tests
- `tests/test_packs_cli.py`: +9 (agent-index runs & exposes metadata, single-pack form, installed-inspect executes, search ranking/sort/no-match/limit-footer/multiword).
- Full pack suite green: **324 passed** (the template-fix turns a previously-red test green).

## Note for reviewers
The metadata backfill + scaffold edit also appear in the in-flight `m9-platform-contract` branch (a live megaplan worker swept the working tree). The **CLI repair + `packs search` + template fix are unique to this branch.** If m9 lands first, the backfill portion here becomes a near-no-op merge.