### PR TITLE
fix: step_failed terminal-kinds divergence — readers disagreed on run completion

### DIFF
--- a/astrid/contracts/run_status.py
+++ b/astrid/contracts/run_status.py
@@ -34,7 +34,39 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Mapping, Sequence
 
-__all__ = ["RunStatus"]
+__all__ = [
+    "RunStatus",
+    "STEP_IN_FLIGHT_KINDS",
+    "STEP_LIFECYCLE_KINDS",
+    "STEP_TERMINAL_KINDS",
+    "TASK_FINALIZABLE_EVENT_KINDS",
+]
+
+
+STEP_TERMINAL_KINDS = frozenset(
+    (
+        "step_completed",
+        "step_failed",
+        "step_skipped",
+        "step_attested",
+    )
+)
+"""Step-level events that resolve a leaf for cursor/progress/completion."""
+
+STEP_IN_FLIGHT_KINDS = frozenset(("step_dispatched", "step_awaiting_fetch"))
+"""Step lifecycle events that keep a leaf active."""
+
+STEP_LIFECYCLE_KINDS = STEP_TERMINAL_KINDS | STEP_IN_FLIGHT_KINDS
+"""Step lifecycle events that can update a leaf's latest lifecycle state."""
+
+TASK_FINALIZABLE_EVENT_KINDS = STEP_TERMINAL_KINDS | frozenset(
+    (
+        "step_awaiting_fetch",
+        "item_completed",
+        "item_attested",
+    )
+)
+"""Event kinds accepted by the task gate finalization wrapper."""
 
 
 class RunStatus(StrEnum):

--- a/astrid/core/task/gate.py
+++ b/astrid/core/task/gate.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, NoReturn, Sequence
 
+from astrid.contracts.run_status import TASK_FINALIZABLE_EVENT_KINDS
 from astrid.core.project.current_run import read_current_run_state
 from astrid.core.project.paths import project_dir
 from astrid.core.session.writer import writer_context_for_project, writer_context_from_decision
@@ -50,6 +51,7 @@ from astrid.core.task.events import (
     make_step_completed_event,
     make_step_dispatched_event,
     make_step_failed_event,
+    make_step_skipped_event,
     read_events,
 )
 from astrid.core.task.plan import (
@@ -124,6 +126,8 @@ from astrid.core.task.gate_checks import (
     _run_inline_checks,
 )
 
+_GATE_FINALIZABLE_EVENT_KINDS = TASK_FINALIZABLE_EVENT_KINDS
+
 
 @dataclass(frozen=True)
 class _ActiveWriterAppend:
@@ -135,15 +139,12 @@ _FinalizeAppendMode = Literal["decision"] | _ActiveWriterAppend
 
 @dataclass(frozen=True)
 class _TerminalEventRequest:
-    kind: Literal[
-        "step_completed",
-        "step_failed",
-        "step_awaiting_fetch",
-        "item_completed",
-        "step_attested",
-        "item_attested",
-    ]
+    kind: str
     payload: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if self.kind not in _GATE_FINALIZABLE_EVENT_KINDS:
+            raise ValueError(f"unknown terminal event kind: {self.kind!r}")
 
 
 @dataclass(frozen=True)
@@ -1176,6 +1177,8 @@ def _finalize_step(
             event = make_step_completed_event(**payload)
         elif terminal_event.kind == "step_failed":
             event = make_step_failed_event(**payload)
+        elif terminal_event.kind == "step_skipped":
+            event = make_step_skipped_event(**payload)
         elif terminal_event.kind == "step_awaiting_fetch":
             event = make_step_awaiting_fetch_event(**payload)
         elif terminal_event.kind == "item_completed":

--- a/astrid/core/task/gate_cursor.py
+++ b/astrid/core/task/gate_cursor.py
@@ -6,6 +6,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Sequence
 
+from astrid.contracts.run_status import STEP_TERMINAL_KINDS
 from astrid.core.task.gate_base import TaskRunGateError
 from astrid.core.task.plan import (
     STEP_PATH_SEP,
@@ -16,6 +17,8 @@ from astrid.core.task.plan import (
     is_group_step,
     is_legacy_repeat_until_condition,
 )
+
+_CURSOR_ADVANCE_KINDS = STEP_TERMINAL_KINDS
 
 
 @dataclass
@@ -61,10 +64,10 @@ def derive_cursor(plan: TaskPlan, events: Sequence[dict[str, Any]], *, slug: str
     """Replay ``events.jsonl`` left-to-right to reconstruct the path-stack cursor.
 
     Reconstructible from events alone (supports partial-replay resume):
-    ``nested_entered`` pushes, ``nested_exited`` pops + advances parent,
-    ``step_completed`` / ``step_attested`` mark a step advance-eligible iff it
-    has no produces; otherwise advance is deferred until the contiguous block
-    contains a ``produces_check_passed`` for every declared produces name.
+    ``nested_entered`` pushes, ``nested_exited`` pops + advances parent.
+    Canonical step terminal events advance the step cursor: successful terminal
+    events with produces wait for matching ``produces_check_passed`` coverage,
+    while failed/skipped terminal events resolve the step immediately.
     ``produces_check_failed`` / ``cursor_rewind`` clear pending state without
     advancing. ``iteration_started`` pushes an iteration frame; ``iteration_failed``
     pops it without advancing the host. ``for_each_expanded`` records the host's
@@ -213,7 +216,7 @@ def derive_cursor(plan: TaskPlan, events: Sequence[dict[str, Any]], *, slug: str
                             else:
                                 frames[-1].child_index += 1
                                 pending[-1] = None
-        elif kind in ("step_completed", "step_attested", "step_skipped"):
+        elif kind in _CURSOR_ADVANCE_KINDS:
             # #20 fix — repeat.until cursor stall: when the topmost frame is
             # an iteration frame whose body is already exhausted (typically
             # because the body's step_attested + produces_check_passed
@@ -275,10 +278,8 @@ def derive_cursor(plan: TaskPlan, events: Sequence[dict[str, Any]], *, slug: str
             ):
                 continue
             produces = getattr(step, "produces", ())
-            # Skipped steps bypass produces-check gating entirely — the
-            # cursor advances on the skip event without waiting for any
-            # produces_check_passed coverage.
-            if kind == "step_skipped" or not produces:
+            # Failed/skipped terminal events bypass produces-check gating entirely.
+            if kind in ("step_failed", "step_skipped") or not produces:
                 top.child_index += 1
                 pending[-1] = None
             else:

--- a/astrid/core/task/operator_view.py
+++ b/astrid/core/task/operator_view.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
-from astrid.contracts.run_status import RunStatus
+from astrid.contracts.run_status import RunStatus, STEP_TERMINAL_KINDS
 from astrid.core.project.current_run import (
     read_current_run_state,
 )
@@ -61,6 +61,8 @@ from astrid.core.task.session_discovery import (
     _print_next_unbound_hint,
 )
 
+_PROGRESS_TERMINAL_KINDS = STEP_TERMINAL_KINDS
+
 
 def _print_err(msg: str) -> None:
     print(msg, file=sys.stderr)
@@ -75,18 +77,17 @@ def _leaf_progress(plan, events: Sequence[dict]) -> tuple[int, int]:
 
     Total counts every leaf path in the plan tree (repeat expansion ignored —
     a for_each host contributes 1, not N). Completed counts distinct leaf
-    paths with a terminal event: step_completed, step_attested, or step_skipped.
+    paths with a terminal event.
     """
     total_paths: set[tuple[str, ...]] = set()
     for path_tuple, step in iter_steps_with_path(plan):
         if is_leaf_step(step):
             total_paths.add(path_tuple)
-    terminal_kinds = {"step_completed", "step_attested", "step_skipped"}
     done_paths: set[tuple[str, ...]] = set()
     for ev in events:
         if not isinstance(ev, dict):
             continue
-        if ev.get("kind") not in terminal_kinds:
+        if ev.get("kind") not in _PROGRESS_TERMINAL_KINDS:
             continue
         raw_path = ev.get("plan_step_path")
         if isinstance(raw_path, list) and raw_path:

--- a/astrid/core/task/run_state.py
+++ b/astrid/core/task/run_state.py
@@ -12,17 +12,21 @@ from __future__ import annotations
 
 from typing import Any
 
+from astrid.contracts.run_status import STEP_LIFECYCLE_KINDS, STEP_TERMINAL_KINDS
 from astrid.core.task.plan import STEP_PATH_SEP, iter_steps_with_path
 
 __all__ = ["_run_is_complete"]
+
+_RUN_STATE_LIFECYCLE_KINDS = STEP_LIFECYCLE_KINDS
+_RUN_STATE_TERMINAL_KINDS = STEP_TERMINAL_KINDS
 
 
 def _run_is_complete(plan: Any, events: list[dict[str, Any]]) -> bool:
     """Return True only when all leaf steps are terminal-non-aborted.
 
-    Terminal-non-aborted means the step has a ``step_completed`` or
-    ``step_failed`` event and is NOT in ``awaiting_fetch`` or ``dispatched``
-    without terminal follow-up.
+    Terminal-non-aborted means the step has one of the canonical step terminal
+    events and is NOT in ``awaiting_fetch`` or ``dispatched`` without terminal
+    follow-up.
     """
     leaves: list[tuple[str, int]] = []
     if hasattr(plan, "steps") and plan.steps is not None:
@@ -45,21 +49,13 @@ def _run_is_complete(plan: Any, events: list[dict[str, Any]]) -> bool:
     # the 12-DeepSeek regression probe: every run hit 6/6 attested but
     # ``_run_is_complete`` returned False because the per-leaf latest_kind was
     # ``produces_check_passed``, not ``step_attested``.
-    _LIFECYCLE_KINDS = {
-        "step_dispatched",
-        "step_completed",
-        "step_failed",
-        "step_skipped",
-        "step_attested",
-        "step_awaiting_fetch",
-    }
     latest_by_path: dict[tuple[str, int], str] = {}
     latest_dispatch_version_by_path: dict[str, int] = {}
     for event in events:
         kind = event.get("kind")
         if not isinstance(kind, str):
             continue
-        if kind not in _LIFECYCLE_KINDS:
+        if kind not in _RUN_STATE_LIFECYCLE_KINDS:
             continue
         raw_version = event.get("step_version")
         path_list = event.get("plan_step_path")
@@ -102,7 +98,7 @@ def _run_is_complete(plan: Any, events: list[dict[str, Any]]) -> bool:
         # ``step_attested`` is the terminal event for attested steps (the gate
         # at gate.py:275 already treats it as advance-eligible alongside the
         # other terminal kinds), so completion must accept it too.
-        if latest_kind not in {"step_completed", "step_failed", "step_skipped", "step_attested"}:
+        if latest_kind not in _RUN_STATE_TERMINAL_KINDS:
             return False
 
     return True

--- a/tests/task/test_step_terminal_contract.py
+++ b/tests/task/test_step_terminal_contract.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from astrid.contracts.run_status import STEP_TERMINAL_KINDS, TASK_FINALIZABLE_EVENT_KINDS
+from astrid.core.task import gate as task_gate
+from astrid.core.task import gate_cursor, operator_view, run_state
+from astrid.core.task.plan import Step, TaskPlan, _validate_plan
+from astrid.core.task.run_state import _run_is_complete
+
+
+def test_step_terminal_consumers_derive_from_canonical_contract() -> None:
+    assert run_state._RUN_STATE_TERMINAL_KINDS is STEP_TERMINAL_KINDS
+    assert gate_cursor._CURSOR_ADVANCE_KINDS is STEP_TERMINAL_KINDS
+    assert operator_view._PROGRESS_TERMINAL_KINDS is STEP_TERMINAL_KINDS
+    assert task_gate._GATE_FINALIZABLE_EVENT_KINDS is TASK_FINALIZABLE_EVENT_KINDS
+    assert STEP_TERMINAL_KINDS <= task_gate._GATE_FINALIZABLE_EVENT_KINDS
+    assert "step_awaiting_fetch" in task_gate._GATE_FINALIZABLE_EVENT_KINDS
+    assert "step_dispatched" not in task_gate._GATE_FINALIZABLE_EVENT_KINDS
+
+
+def test_step_terminal_consumers_do_not_hand_roll_terminal_sets() -> None:
+    module_paths = (
+        Path(run_state.__file__),
+        Path(gate_cursor.__file__),
+        Path(operator_view.__file__),
+        Path(task_gate.__file__),
+    )
+    for module_path in module_paths:
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Set):
+                continue
+            literals = {
+                elt.value
+                for elt in node.elts
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+            }
+            hand_rolled_terminal = literals & STEP_TERMINAL_KINDS
+            assert len(hand_rolled_terminal) < 3, (
+                f"{module_path} hand-rolls step terminal kinds: "
+                f"{sorted(hand_rolled_terminal)!r}"
+            )
+
+
+def test_step_failed_terminal_state_is_consistent_across_readers() -> None:
+    plan = TaskPlan(
+        plan_id="terminal-failed",
+        version=2,
+        steps=(Step(id="render", adapter="local", command="false"),),
+    )
+    events = [
+        {"kind": "run_started", "run_id": "run-1"},
+        {
+            "kind": "step_dispatched",
+            "plan_step_path": ["render"],
+            "command": "false",
+            "step_version": 1,
+            "hash": "sha256:dispatch",
+        },
+        {
+            "kind": "step_failed",
+            "plan_step_path": ["render"],
+            "returncode": 1,
+            "reason": "nonzero exit",
+            "step_version": 1,
+            "dispatch_event_hash": "sha256:dispatch",
+        },
+    ]
+
+    assert _run_is_complete(plan, events) is True
+    assert gate_cursor.derive_cursor(plan, events).at_root_done is True
+    assert operator_view._leaf_progress(plan, events) == (1, 1)
+
+
+def test_step_failed_with_produces_does_not_wait_for_successful_produces_checks() -> None:
+    plan = _validate_plan(
+        {
+            "plan_id": "terminal-failed-produces",
+            "version": 2,
+            "steps": [
+                {
+                    "id": "render",
+                    "adapter": "local",
+                    "command": "false",
+                    "produces": {
+                        "output": {
+                            "path": "out.txt",
+                            "check": {"check_id": "file_nonempty", "params": {}},
+                        }
+                    },
+                }
+            ],
+        }
+    )
+    events = [
+        {"kind": "run_started", "run_id": "run-1"},
+        {"kind": "step_dispatched", "plan_step_path": ["render"], "step_version": 1},
+        {"kind": "step_failed", "plan_step_path": ["render"], "returncode": 1, "step_version": 1},
+    ]
+
+    assert _run_is_complete(plan, events) is True
+    assert gate_cursor.derive_cursor(plan, events).at_root_done is True
+    assert operator_view._leaf_progress(plan, events) == (1, 1)


### PR DESCRIPTION
Found by the 2026-06-04 formalization audit (8-agent contracts sweep), fixed by a Codex subagent, verified locally (231 task tests green).

**The bug:** 4 definitions of "terminal step event" existed. `derive_cursor` and `_leaf_progress` omitted `step_failed`; `_run_is_complete` included it. After a `step_failed` event, the run reported complete while the gate cursor never advanced past the failed step and the progress meter undercounted — readers disagreed about whether the run was done.

**Intent verdict:** `step_failed` IS terminal — retries are explicit (`step_awaiting_fetch`/supersede), never automatic from a failure.

**The contract:** canonical frozen `STEP_TERMINAL_KINDS` in `contracts/run_status.py`; all four consumers derive from it; AST-scan conformance test rejects future hand-rolled terminal sets; regression test pins reader agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)