### PR TITLE
Integrate Hivemind v2 contributor-auth contract

### DIFF
--- a/astrid/core/pack/source_setup.py
+++ b/astrid/core/pack/source_setup.py
@@ -31,9 +31,14 @@ DEFAULT_PROFILE = "default"
 SOURCE_DECLARATIONS_ENV = "ASTRID_SOURCE_DECLARATIONS"
 SOURCE_STATE_ENV = "ASTRID_SOURCE_STATE"
 SOURCE_DATA_ENV = "ASTRID_SOURCE_DATA"
+HIVEMIND_REVISION_ENV = "ASTRID_HIVEMIND_REVISION"
+HIVEMIND_REPOSITORY_ENV = "ASTRID_HIVEMIND_REPOSITORY"
 _OID_LENGTHS = {40, 64}
 DEFAULT_HIVEMIND_REPOSITORY = "https://github.com/banodoco/hivemind.git"
-DEFAULT_HIVEMIND_REVISION = "50ff509240c5582a7335dc71920533b59be7792c"
+# Delivery pin: local immutable Hivemind commit containing the v2 pack and
+# contributor-auth implementation. Publication to the upstream remote remains
+# outside this task; a caller may override the repository for local rehearsal.
+DEFAULT_HIVEMIND_REVISION = "a4c6610cba1032adb3b4bec541ccf821afba6ba8"
 
 
 class SourceSetupError(RuntimeError):
@@ -97,22 +102,57 @@ class SourceDeclaration:
 
 
 def default_source_declarations() -> tuple[SourceDeclaration, ...]:
-    """Return the versioned default external source policy.
+    """Return the configured default external source policy.
 
-    The repository pin is intentionally separate from the installed source
-    inventory.  Setup may be pointed at a local Git mirror through
-    ``ASTRID_SOURCE_DECLARATIONS`` for offline development, while a normal
-    installation uses the canonical upstream URL at the same immutable
-    revision.
+    The Hivemind revision is pinned to a full immutable delivery commit and
+    may be overridden for a later published commit. The repository override is
+    useful for local rehearsal; normal installs use the canonical upstream URL.
+    ``ASTRID_SOURCE_DECLARATIONS`` remains available for a complete declaration
+    file and is resolved by ``declarations_from_json``.
     """
+    revision = os.environ.get(HIVEMIND_REVISION_ENV, DEFAULT_HIVEMIND_REVISION).strip()
+    repository = os.environ.get(HIVEMIND_REPOSITORY_ENV, DEFAULT_HIVEMIND_REPOSITORY).strip()
+    try:
+        declaration = SourceDeclaration.from_mapping(
+            {
+                "pack_id": "hivemind",
+                "repository": repository,
+                "revision": revision,
+                "pack_subpath": ".",
+            }
+        )
+    except SourceSetupError as exc:
+        raise SourceSetupError(
+            f"{HIVEMIND_REVISION_ENV} must contain a full immutable Hivemind Git object id"
+        ) from exc
     return (
-        SourceDeclaration(
-            pack_id="hivemind",
-            repository=DEFAULT_HIVEMIND_REPOSITORY,
-            revision=DEFAULT_HIVEMIND_REVISION,
-            pack_subpath=".",
-        ),
+        declaration,
     )
+
+
+def hivemind_pin_report(
+    declarations: Iterable[SourceDeclaration] = (),
+) -> dict[str, Any]:
+    """Describe the Hivemind pin without claiming unresolved source readiness."""
+    selected = next((item for item in declarations if item.pack_id == "hivemind"), None)
+    if selected is not None:
+        return {
+            "pack_id": "hivemind",
+            "status": "configured",
+            "repository": selected.repository,
+            "revision": selected.revision,
+            "source": "ASTRID_HIVEMIND_REVISION"
+            if os.environ.get(HIVEMIND_REVISION_ENV, "").strip() == selected.revision
+            else "ASTRID_SOURCE_DECLARATIONS",
+        }
+    return {
+        "pack_id": "hivemind",
+        "status": "configured",
+        "repository": DEFAULT_HIVEMIND_REPOSITORY,
+        "revision": DEFAULT_HIVEMIND_REVISION,
+        "configuration": HIVEMIND_REVISION_ENV,
+        "message": "Hivemind is pinned to the local delivery commit; publish it before remote installation.",
+    }
 
 
 @dataclass(frozen=True)
@@ -390,7 +430,9 @@ def provision(
         state["disabled"] = sorted(set(state.get("disabled", [])) | {disable_pack})
         if not check:
             _write_state(state, state_path)
-        return inventory_report(state, check=check)
+        report = inventory_report(state, check=check)
+        report["hivemind_pin"] = hivemind_pin_report(declarations)
+        return report
     if restore_pack:
         if restore_pack not in by_id:
             raise SourceSetupError(f"no declaration for pack {restore_pack!r}")
@@ -414,11 +456,17 @@ def provision(
             errors.append(str(exc))
         if errors:
             if check:
-                return {**inventory_report(state, check=True), "ok": False, "errors": errors}
+                report = inventory_report(state, check=True)
+                report["ok"] = False
+                report["errors"] = errors
+                report["hivemind_pin"] = hivemind_pin_report(declarations)
+                return report
             raise SourceSetupError("; ".join(errors))
     if not check:
         _write_state(state, state_path)
-    return inventory_report(state, check=check)
+    report = inventory_report(state, check=check)
+    report["hivemind_pin"] = hivemind_pin_report(declarations)
+    return report
 
 
 def inventory_report(state: Mapping[str, Any] | None = None, *, check: bool = True) -> dict[str, Any]:
@@ -494,10 +542,12 @@ def _cli(argv: list[str] | None = None) -> int:
 
 __all__ = [
     "DEFAULT_HIVEMIND_REPOSITORY", "DEFAULT_HIVEMIND_REVISION", "DEFAULT_PROFILE",
+    "HIVEMIND_REVISION_ENV", "HIVEMIND_REPOSITORY_ENV",
     "InstalledSource", "ManagedSourceInventory", "SOURCE_DATA_ENV",
     "SOURCE_DECLARATIONS_ENV", "SOURCE_STATE_ENV", "SourceDeclaration", "SourceSetupError",
     "active_source_inventory", "active_sources",
-    "default_source_declarations", "declarations_from_json", "inventory_report", "provision", "source_data_root",
+    "default_source_declarations", "declarations_from_json", "hivemind_pin_report",
+    "inventory_report", "provision", "source_data_root",
     "source_inventory_identity", "source_state_path",
 ]
 

--- a/astrid/packs/_core/skill/SKILL.md
+++ b/astrid/packs/_core/skill/SKILL.md
@@ -20,7 +20,7 @@ Choose the route by the requested result. Read only that route's guidance:
 | Generate images, video, or audio (including Foley); understand, assemble, compare, or publish work | [Creative work](creative-work/SKILL.md), then the relevant pack |
 | Reuse a character or other saved subject | [References](../../references/skill/SKILL.md) |
 | Build your own reusable tool, workflow, or visual element | [Pack builder](pack-builder/SKILL.md) |
-| Find Banodoco advice, model settings, or workflow precedents | [Hivemind](../../hivemind/skill/SKILL.md) |
+| Find Banodoco advice, model settings, or workflow precedents | [Hivemind](packs/hivemind/SKILL.md) |
 
 Using an existing workflow and building a reusable extension are different
 requests: pack builder handles the latter, including deciding what to reuse.
@@ -144,9 +144,11 @@ runtime/SDK error, and `2` a usage or parse error.
 ## Shared knowledge: Hivemind
 
 For community practice, model behavior, settings, known failures, and workflow
-precedents, read the [Hivemind pack skill](../../hivemind/skill/SKILL.md).
-Hivemind ships with Astrid by default. Use its search capability, then retrieve
-the full source behind useful hits before presenting community advice.
+precedents, read the [Hivemind pack skill](packs/hivemind/SKILL.md) when the
+managed external pack is installed. Use its search capability, then retrieve
+the full source behind useful hits before presenting community advice. The
+Astrid-side v2 compatibility and contributor-write contract is documented in
+[`docs/reference/hivemind-pack-contract.md`](../../docs/reference/hivemind-pack-contract.md).
 
 The skill and executors belong to that pack. If the default pack or its skill is
 missing, follow the pack's documented installation recovery; do not redirect to

--- a/astrid/packs/_core/skill/creative-work/SKILL.md
+++ b/astrid/packs/_core/skill/creative-work/SKILL.md
@@ -51,7 +51,7 @@ selected pack, normally a project `runs/` tree.
 
 ## Hivemind before creative decisions
 
-Search [Hivemind](../../../hivemind/skill/SKILL.md) before choosing an unfamiliar model, setting, workflow pattern,
+Search [Hivemind](../packs/hivemind/SKILL.md) before choosing an unfamiliar model, setting, workflow pattern,
 or workaround. This is especially useful for ComfyUI/VibeComfy graphs,
 generation settings, rendering failures, and known community solutions. Use
 `hivemind.get_item` for the full evidence behind a useful result. Treat

--- a/astrid/packs/_core/skill/references/capabilities.md
+++ b/astrid/packs/_core/skill/references/capabilities.md
@@ -122,3 +122,12 @@
 | `transitions/fade` | Fade-through-black transition. |
 
 <!-- END CAPABILITY INDEX -->
+
+### Hivemind external-pack contract
+
+The managed Hivemind pack is admitted only after its v2 manifest and immutable
+source pin validate. Its public reads remain anonymous; contributor operations,
+the three ingestion writers, and `submit-vibecomfy-rating` use Hivemind's
+contributor-authenticated backend. See
+[`docs/reference/hivemind-pack-contract.md`](../../../../docs/reference/hivemind-pack-contract.md)
+and [`config/hivemind-pack-contract.json`](../../../../config/hivemind-pack-contract.json).

--- a/config/hivemind-pack-contract.json
+++ b/config/hivemind-pack-contract.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 2,
+  "pack_id": "hivemind",
+  "manifest": {
+    "schema_version": 2,
+    "content": {
+      "executors": "executors"
+    },
+    "capabilities": [
+      "search_corpus",
+      "get_item",
+      "refresh_media",
+      "submit_resource",
+      "propose_revision",
+      "submit_evidence",
+      "ingest_article",
+      "ingest_workflow",
+      "ingest_youtube",
+      "submit_vibecomfy_rating"
+    ]
+  },
+  "executors": [
+    "hivemind.search",
+    "hivemind.get_item",
+    "hivemind.refresh_media",
+    "hivemind.contribute",
+    "hivemind.ingest_article",
+    "hivemind.ingest_workflow",
+    "hivemind.ingest_youtube"
+  ],
+  "public_reads": {
+    "authentication": "anonymous",
+    "environment": ["HIVEMIND_API_URL", "HIVEMIND_ANON_KEY"],
+    "capabilities": [
+      "hivemind.search",
+      "hivemind.get_item",
+      "hivemind.refresh_media"
+    ]
+  },
+  "contributor_writers": {
+    "authentication": "HIVEMIND_CONTRIBUTOR_KEY",
+    "resource_backend": "contribute",
+    "operations": [
+      "submit_resource",
+      "propose_revision",
+      "decide_revision",
+      "mark_canonical",
+      "capture_message_snapshot",
+      "submit_evidence"
+    ],
+    "capabilities": [
+      "hivemind.contribute",
+      "hivemind.ingest_article",
+      "hivemind.ingest_workflow",
+      "hivemind.ingest_youtube",
+      "hivemind.submit_vibecomfy_rating"
+    ],
+    "ingestors_use_same_backend": true
+  },
+  "rating_writer": {
+    "endpoint": "submit-vibecomfy-rating",
+    "authentication": "HIVEMIND_CONTRIBUTOR_KEY",
+    "backend": "hivemind contributor identity and service-role boundary",
+    "capability_id": "hivemind.submit_vibecomfy_rating"
+  },
+  "source_pin": {
+    "repository": "https://github.com/banodoco/hivemind.git",
+    "delivery_revision": "a4c6610cba1032adb3b4bec541ccf821afba6ba8",
+    "configuration": "ASTRID_HIVEMIND_REVISION",
+    "requires_full_immutable_git_object_id": true,
+    "unresolved_until_published_v2_commit": false,
+    "remote_publication_required_before_install": true
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,11 +23,15 @@ python3 -m astrid --help
 python3 -m astrid projects list --json
 ```
 
-### Default Hivemind pack
+### Optional Hivemind pack
 
-Astrid setup provisions the canonical Hivemind repository at an immutable
-revision, validates its strict v2 pack manifest, and composes its skill view.
-The same managed source inventory is used by discovery and the generic host:
+Astrid pins the Hivemind v2 delivery commit through the explicit
+`ASTRID_HIVEMIND_REVISION` seam. The delivery checkout has a concrete
+immutable pin; the canonical remote must publish that commit before a remote
+installation can use it. Until then, point `ASTRID_HIVEMIND_REPOSITORY` at a
+local Hivemind checkout (or provide a complete local source declaration). Setup
+validates the strict v2 pack manifest and composes its skill view; it fails
+closed if the pinned object cannot be fetched rather than following `HEAD`:
 
 ```bash
 python3 -m astrid.setup
@@ -36,9 +40,15 @@ python3 -m astrid.setup --disable-pack hivemind
 python3 -m astrid.setup --restore-pack hivemind
 ```
 
-Use `ASTRID_SOURCE_DECLARATIONS` or `--declarations` for a local Git mirror
-when developing offline. Skill sync is read-only with respect to source
-acquisition; Hivemind corpus search and retrieval still require network access.
+The delivery pin is already the complete 40-character Git object id. Override
+`ASTRID_HIVEMIND_REVISION` only with another full immutable Hivemind object id,
+and use `ASTRID_HIVEMIND_REPOSITORY` for a local mirror or checkout during
+rehearsal. `ASTRID_SOURCE_DECLARATIONS` or `--declarations` remains available
+for a complete local Git declaration. Skill sync is read-only with respect to
+source acquisition; Hivemind corpus search and retrieval still require
+network access. See the
+[Hivemind external-pack contract](reference/hivemind-pack-contract.md) for
+the v2 metadata, anonymous reads, and contributor-write routes.
 
 Use that environment for later commands too. The render worker checks its
 dependencies in an isolated Python process, so user-site-only installations

--- a/docs/reference/hivemind-pack-contract.md
+++ b/docs/reference/hivemind-pack-contract.md
@@ -1,0 +1,68 @@
+# Hivemind external-pack contract
+
+This is Astrid-side compatibility metadata for the independently maintained
+Hivemind pack. The machine-readable contract is
+[`config/hivemind-pack-contract.json`](../../config/hivemind-pack-contract.json).
+Astrid does not vendor Hivemind executors, copy its backend, or treat this
+document as evidence that the external pack is installed.
+
+## Admission and source pin
+
+The managed source must contain a canonical `pack.yaml` with
+`schema_version: 2`, the `hivemind` pack id, and the executor content root.
+Astrid validates that manifest before activation and records the exact source
+revision and tree digests.
+
+The delivery worktree pins the first admissible Hivemind commit at
+`a4c6610cba1032adb3b4bec541ccf821afba6ba8`. It contains the v2 manifest and
+the contributor-auth implementation. The commit is local to this delivery
+branch; remote publication is intentionally outside this task. Until that
+commit (or a later full SHA) is published to the upstream repository, remote
+installation must use an explicit local source declaration or remain pending.
+
+When the v2 commit exists, configure its complete 40- or 64-character Git
+object id:
+
+```bash
+export ASTRID_HIVEMIND_REVISION=a4c6610cba1032adb3b4bec541ccf821afba6ba8
+python3 -m astrid.setup --check
+```
+
+Astrid never follows a branch and never turns a short or invented SHA into a
+managed source pin. For local rehearsal, set
+`ASTRID_HIVEMIND_REPOSITORY=file:///absolute/path/to/hivemind` alongside the
+delivery revision.
+
+## Capability coverage
+
+The v2 pack metadata must retain these public reads, which use Hivemind's
+anonymous/public configuration and never require a contributor key:
+
+- `hivemind.search`
+- `hivemind.get_item`
+- `hivemind.refresh_media`
+
+Contributor-authenticated writes use `HIVEMIND_CONTRIBUTOR_KEY`. Resource
+submission, revision proposals and decisions, canonical-guide marking, message
+snapshots, and evidence submission all reuse Hivemind's existing `contribute`
+backend. The active contributor operations are `submit_resource`,
+`propose_revision`, `decide_revision`, `mark_canonical`,
+`capture_message_snapshot`, and `submit_evidence`. The three ingestion helpers
+submit through that same resource path:
+
+- `hivemind.contribute`
+- `hivemind.ingest_article`
+- `hivemind.ingest_workflow`
+- `hivemind.ingest_youtube`
+- `hivemind.submit_vibecomfy_rating`
+
+The `submit-vibecomfy-rating` writer remains covered as a separate Hivemind
+edge-function route. It uses the same contributor identity check and
+service-role boundary; it is not a public read and does not create an Astrid
+second writer. Its Astrid compatibility id is
+`hivemind.submit_vibecomfy_rating`.
+
+The existing Astrid capability matrix keeps executor discovery separate from
+these backend operations. The rating route and the contributor operation names
+are therefore recorded in the external-pack contract rather than advertised as
+in-tree Astrid executors before the v2 Hivemind pack is available.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -133,8 +133,10 @@ discovers 59 executable in-tree executor manifests. Historical external rows
 local capabilities. The host re-runs preflight before each runtime claim, so
 the capability IDs offered for admission are exactly the capabilities that
 are currently ready. The projection also retains 19 retired pre-cutover Reigh
-IDs and records the unresolved seven-declared/eight-installed Hivemind census
-without guessing the eighth ID.
+IDs. Hivemind's v2 executor and contributor-operation coverage is maintained
+in the Astrid-side [external-pack contract](hivemind-pack-contract.md). The
+delivery configuration carries a full immutable source pin; setup does not
+count the pack as installed unless that exact object is locally available.
 
 ### Schema Inspection
 

--- a/tests/core/pack/test_source_setup.py
+++ b/tests/core/pack/test_source_setup.py
@@ -11,11 +11,14 @@ from astrid.core.pack.discovery import discover_canonical_pack_metadata, discove
 from astrid.core.pack.source_setup import (
     DEFAULT_HIVEMIND_REPOSITORY,
     DEFAULT_HIVEMIND_REVISION,
+    HIVEMIND_REPOSITORY_ENV,
+    HIVEMIND_REVISION_ENV,
     SourceDeclaration,
     SourceSetupError,
     active_source_inventory,
     declarations_from_json,
     default_source_declarations,
+    hivemind_pin_report,
     provision,
 )
 from astrid.sdk.discovery import _discover_pack_inventory
@@ -57,17 +60,36 @@ def _fixture_repo(root: Path, *, schema_version: int = 2) -> str:
     return _git(root, "rev-parse", "HEAD")
 
 
-def test_default_source_policy_pins_the_canonical_external_hivemind_revision(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_source_policy_uses_full_delivery_hivemind_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("ASTRID_SOURCE_DECLARATIONS", raising=False)
+    monkeypatch.delenv(HIVEMIND_REVISION_ENV, raising=False)
+    monkeypatch.delenv(HIVEMIND_REPOSITORY_ENV, raising=False)
+    declarations = default_source_declarations()
+    assert declarations[0].revision == DEFAULT_HIVEMIND_REVISION
+    assert declarations[0].repository == DEFAULT_HIVEMIND_REPOSITORY
+    assert hivemind_pin_report(declarations)["status"] == "configured"
+
+
+def test_default_source_policy_accepts_only_a_configured_full_immutable_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revision = "a" * 40
+    monkeypatch.setenv(HIVEMIND_REVISION_ENV, revision)
     declarations = default_source_declarations()
     assert declarations == (
         SourceDeclaration(
             pack_id="hivemind",
             repository=DEFAULT_HIVEMIND_REPOSITORY,
-            revision=DEFAULT_HIVEMIND_REVISION,
+            revision=revision,
         ),
     )
-    assert declarations_from_json() == declarations
+    assert hivemind_pin_report(declarations)["status"] == "configured"
+
+    monkeypatch.setenv(HIVEMIND_REVISION_ENV, "deadbeef")
+    with pytest.raises(SourceSetupError, match="full immutable Hivemind Git object id"):
+        default_source_declarations()
 
 
 def test_local_git_v2_source_is_staged_once_and_shared(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -122,6 +144,20 @@ def test_local_git_v2_source_is_staged_once_and_shared(monkeypatch: pytest.Monke
     )
     assert restored["ok"] is True
     assert active_source_inventory(state_path=state_path).sources[0].revision == revision
+
+
+def test_managed_source_requires_strict_v2_manifest(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    revision = _fixture_repo(repository, schema_version=1)
+    state_path = tmp_path / "state" / "pack-sources.json"
+    data_root = tmp_path / "data"
+    declaration = SourceDeclaration.from_mapping(
+        {"pack_id": "demo", "repository": str(repository), "revision": revision}
+    )
+
+    with pytest.raises(SourceSetupError, match="strict v2 admission"):
+        provision((declaration,), state_path=state_path, data_root=data_root)
+    assert not state_path.exists()
 
 
 def test_invalid_update_keeps_prior_active_state(tmp_path: Path) -> None:

--- a/tests/test_hivemind_pack_contract.py
+++ b/tests/test_hivemind_pack_contract.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "config" / "hivemind-pack-contract.json"
+DOC = ROOT / "docs" / "reference" / "hivemind-pack-contract.md"
+
+
+def test_hivemind_v2_contract_covers_reads_and_all_contributor_writers() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    assert contract["schema_version"] == 2
+    assert contract["pack_id"] == "hivemind"
+    assert contract["manifest"]["schema_version"] == 2
+    assert contract["public_reads"] == {
+        "authentication": "anonymous",
+        "environment": ["HIVEMIND_API_URL", "HIVEMIND_ANON_KEY"],
+        "capabilities": [
+            "hivemind.search",
+            "hivemind.get_item",
+            "hivemind.refresh_media",
+        ],
+    }
+    assert contract["contributor_writers"]["authentication"] == "HIVEMIND_CONTRIBUTOR_KEY"
+    assert contract["contributor_writers"]["resource_backend"] == "contribute"
+    assert contract["contributor_writers"]["ingestors_use_same_backend"] is True
+    assert contract["rating_writer"] == {
+        "endpoint": "submit-vibecomfy-rating",
+        "authentication": "HIVEMIND_CONTRIBUTOR_KEY",
+        "backend": "hivemind contributor identity and service-role boundary",
+        "capability_id": "hivemind.submit_vibecomfy_rating",
+    }
+
+
+def test_hivemind_contract_docs_match_machine_readable_route_names() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    for capability_id in contract["public_reads"]["capabilities"] + contract["contributor_writers"]["capabilities"]:
+        assert f"`{capability_id}`" in text
+    for operation in contract["contributor_writers"]["operations"]:
+        assert operation in text
+    assert "submit-vibecomfy-rating" in text
+    assert "ASTRID_HIVEMIND_REVISION" in text
+    assert "schema_version: 2" in text


### PR DESCRIPTION
## Summary
- Add strict schema-v2 external-pack admission and immutable Hivemind source pinning.
- Pin the delivery contract to Hivemind commit a4c6610cba1032adb3b4bec541ccf821afba6ba8.
- Document anonymous reads, contributor-authenticated writers, editor separation, and the Banodoco approval flow.
- Add source-pin and external-contract tests.

## Verification
- Python syntax and source/config/docs pin checks pass.
- Full pytest/strict-admission reruns remain environment-limited because pytest and PyYAML are unavailable locally.

The Hivemind product implementation is supplied by the companion Hivemind PR. No deployment is included.